### PR TITLE
fix delete() and add getQueue() methods

### DIFF
--- a/src/FintechFab/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/FintechFab/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -45,7 +45,18 @@ class RabbitMQJob extends Job
 	 */
 	public function delete()
 	{
+		parent::delete();
 		$this->queue->ack($this->envelope->getDeliveryTag());
+	}
+
+	/**
+	 * Get queue name
+	 *
+	 * @return string
+	 */
+	public function getQueue()
+	{
+		return $this->queue->getName();
 	}
 
 	/**


### PR DESCRIPTION
delete() must call parent delete() in order to properly mark the job deleted. getQueue() must be implemented since the inherited $queue which should be a string is being replaced by the AMQPQueue object. this should actually be changed to its own $amqp variable and $queue should always be a string
