### PR TITLE
Export internal exchange property

### DIFF
--- a/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -161,6 +161,13 @@ class RabbitMQQueue extends Queue implements QueueInterface
 	}
 
 	/**
+	 * @return AMQPExchange
+	 */
+	public function getCurrentExchange() {
+		return $this->exchange;
+	}
+
+	/**
 	 * @param AMQPChannel $channel
 	 *
 	 * @return AMQPExchange


### PR DESCRIPTION
We need to publish messages via pushRaw on a fanout-exchange, which is configured manually in RabbitMQ. So it's easier to take the exchange directly to publish messages.
As it's much cleaner to take the whole configuration of laravel for granted, we don't want to establish a new connection apart from the laravel-queue-rabbit-mq module.
