### PR TITLE
[5.1] Allow custom properties when publishing a job

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -71,11 +71,17 @@ class RabbitMQQueue extends Queue implements QueueContract
 			$queue = $this->declareDelayedQueue($queue, $options['delay']);
 		}
 
-		// push job to a queue
-		$message = new AMQPMessage($payload, [
+		$properties = [
 			'Content-Type'  => 'application/json',
 			'delivery_mode' => 2,
-		]);
+		];
+
+		if (isset($options['properties']) && is_array($options['properties'])) {
+			$properties = array_merge($properties, $options['properties']);
+		}
+
+		// push job to a queue
+		$message = new AMQPMessage($payload, $properties);
 
 		// push task to a queue
 		$this->channel->basic_publish($message, $queue, $queue);


### PR DESCRIPTION
RabbitMQ supports additional properties on the message beyond the delivery mode and content type. These properties can be used for sending metadata along the published payload, which can be very useful if the message consumer is written in something other than Laravel.
