### PR TITLE
Added support for SSL connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ RabbitMQ Queue driver for Laravel
 		RABBITMQ_LOGIN=guest
 		RABBITMQ_PASSWORD=guest
 		RABBITMQ_QUEUE=queue_name
+		
+4. Optionally: if you want to to use SSL add these properties to `.env` with proper values:
+        
+        RABBITMQ_SSL=true
+        
+        SSL_CAFILE=/path/to/your/ca/cacert.pem
+        SSL_LOCALCERT=
+        SSL_PASSPHRASE=
+        SSL_KEY=
+ 
+Using an SSL connection will also require to configure your RabbitMQ to enable SSL first!
 
 
 You can also find full examples in src/examples folder.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,8 @@
     <php>
         <env name="HOST" value="127.0.0.1"/>
         <env name="PORT" value="5672"/>
+        <env name="PORT_SSL" value="5671"/>
+        <env name="SSL_CAFILE" value="/path_to_your_ca_file"/>
     </php>
     <filter>
         <whitelist>

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/LaravelQueueRabbitMQServiceProvider.php
@@ -5,6 +5,7 @@ namespace VladimirYuldashev\LaravelQueueRabbitMQ;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\ServiceProvider;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnector;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnectorSSL;
 
 class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
 {
@@ -29,7 +30,12 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
     {
         /** @var QueueManager $queue */
         $queue = $this->app['queue'];
-        $connector = new RabbitMQConnector();
+
+        if ($this->app['config']['rabbitmq']['ssl_params']['ssl_on'] === true) {
+            $connector = new RabbitMQConnectorSSL();
+        } else {
+            $connector = new RabbitMQConnector();
+        }
 
         $queue->stopping(function () use ($connector) {
             $connector->connection()->close();

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Connectors/RabbitMQConnectorSSL.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Connectors/RabbitMQConnectorSSL.php
@@ -21,7 +21,7 @@ class RabbitMQConnectorSSL implements ConnectorInterface
     public function connect(array $config)
     {
         // Remove null values from the SSL config
-        foreach($config['ssl_params'] as $idx => $option) {
+        foreach ($config['ssl_params'] as $idx => $option) {
             if ($option === null || empty($option)) {
                 unset($config['ssl_params'][$idx]);
             }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Connectors/RabbitMQConnectorSSL.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Connectors/RabbitMQConnectorSSL.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors;
+
+use Illuminate\Queue\Connectors\ConnectorInterface;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class RabbitMQConnectorSSL implements ConnectorInterface
+{
+    /** @var AMQPSSLConnection */
+    private $connection;
+
+    /**
+     * Establish a queue connection.
+     *
+     * @param array $config
+     *
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        // Remove null values from the SSL config
+        foreach($config['ssl_params'] as $idx => $option) {
+            if ($option === null || empty($option)) {
+                unset($config['ssl_params'][$idx]);
+            }
+        }
+
+        // Create connection with AMQP
+        $this->connection = new AMQPSSLConnection(
+            $config['host'],
+            $config['port'],
+            $config['login'],
+            $config['password'],
+            $config['vhost'],
+            $config['ssl_params']
+        );
+
+        return new RabbitMQQueue(
+            $this->connection,
+            $config
+        );
+    }
+
+    public function connection()
+    {
+        return $this->connection;
+    }
+}

--- a/src/config/rabbitmq.php
+++ b/src/config/rabbitmq.php
@@ -44,4 +44,13 @@ return [
     // if set to false, it'll throw an exception rather than doing the sleep for X seconds
     'sleep_on_error' => env('RABBITMQ_ERROR_SLEEP', 5),
 
+    // Optional SSL params
+    'ssl_params' => [
+        'ssl_on'        => env('RABBITMQ_SSL', false),
+        'cafile'        => env('SSL_CAFILE', null),
+        'local_cert'    => env('SSL_LOCALCERT', null),
+        'verify_peer'   => env('SSL_VERIFY_PEER', true),
+        'passphrase'    => env('SSL_PASSPHRASE', null),
+    ]
+
 ];

--- a/tests/RabbitMQConnectorSSLTest.php
+++ b/tests/RabbitMQConnectorSSLTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+use PHPUnit\Framework\TestCase;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnectorSSL;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class RabbitMQConnectorSSLTest extends TestCase
+{
+    public function test_connect()
+    {
+        $config = [
+            'host'     => getenv('HOST'),
+            'port'     => getenv('PORT_SSL'),
+            'login'    => 'guest',
+            'password' => 'guest',
+            'vhost'    => '/',
+
+            'queue'              => 'queue_name',
+            'exchange_declare'   => true,
+            'queue_declare_bind' => true,
+
+            'queue_params' => [
+                'passive'     => false,
+                'durable'     => true,
+                'exclusive'   => false,
+                'auto_delete' => false,
+            ],
+            'exchange_params' => [
+                'name'        => null,
+                'type'        => 'direct',
+                'passive'     => false,
+                'durable'     => true,
+                'auto_delete' => false,
+            ],
+            'ssl_params' => [
+                'cafile'        => getenv('SSL_CAFILE')
+            ]
+        ];
+
+        $connector = new RabbitMQConnectorSSL();
+        $queue = $connector->connect($config);
+
+        $this->assertInstanceOf(RabbitMQQueue::class, $queue);
+        $this->assertInstanceOf(AMQPSSLConnection::class, $connector->connection());
+    }
+}


### PR DESCRIPTION
This allows to use RabbitMQ via SSL. The minimum requirement for this is having a CA file (can be self-signed).