### PR TITLE
Queue params

### DIFF
--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -39,6 +39,7 @@ return [
         'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
         'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
         'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
+        'arguments'   => env('RABBITMQ_QUEUE_ARGUMENTS', false),
     ],
     'exchange_params' => [
         'name' => env('RABBITMQ_EXCHANGE_NAME', null),

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -39,7 +39,7 @@ return [
         'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
         'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
         'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
-        'arguments'   => json_decode(env('RABBITMQ_QUEUE_ARGUMENTS', '{}'), 1),
+        'arguments'   => env('RABBITMQ_QUEUE_ARGUMENTS', null),
     ],
     'exchange_params' => [
         'name' => env('RABBITMQ_EXCHANGE_NAME', null),

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -39,7 +39,7 @@ return [
         'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
         'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
         'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
-        'arguments'   => env('RABBITMQ_QUEUE_ARGUMENTS', false),
+        'arguments'   => json_decode(env('RABBITMQ_QUEUE_ARGUMENTS', '{}'), 1),
     ],
     'exchange_params' => [
         'name' => env('RABBITMQ_EXCHANGE_NAME', null),

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -33,6 +33,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
     protected $defaultQueue;
     protected $configQueue;
+    protected $configQueueArguments;
     protected $configExchange;
 
     /**
@@ -54,6 +55,7 @@ class RabbitMQQueue extends Queue implements QueueContract
         $this->connection = $amqpConnection;
         $this->defaultQueue = $config['queue'];
         $this->configQueue = $config['queue_params'];
+        $this->configQueueArguments = json_decode($this->configQueue['arguments'], 1) ?: [];
         $this->configExchange = $config['exchange_params'];
         $this->declareExchange = $config['exchange_declare'];
         $this->declareBindQueue = $config['queue_declare_bind'];
@@ -231,7 +233,7 @@ class RabbitMQQueue extends Queue implements QueueContract
                 $this->configQueue['exclusive'],
                 $this->configQueue['auto_delete'],
                 false,
-                new AMQPTable($this->configQueue['arguments'])
+                new AMQPTable($this->configQueueArguments)
             );
 
             // bind queue to the exchange
@@ -274,7 +276,7 @@ class RabbitMQQueue extends Queue implements QueueContract
                     'x-dead-letter-exchange'    => $destinationExchange,
                     'x-dead-letter-routing-key' => $destination,
                     'x-message-ttl'             => $delay * 1000,
-                ], (array)$this->configQueue['arguments']);
+                ], (array)$this->configQueueArguments);
             
             $this->channel->queue_declare(
                 $name,

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -229,7 +229,9 @@ class RabbitMQQueue extends Queue implements QueueContract
                 $this->configQueue['passive'],
                 $this->configQueue['durable'],
                 $this->configQueue['exclusive'],
-                $this->configQueue['auto_delete']
+                $this->configQueue['auto_delete'],
+                false,
+                $this->configQueue['arguments']
             );
 
             // bind queue to the exchange
@@ -268,6 +270,12 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // declare queue
         if (!in_array($name, $this->declaredQueues, true)) {
+            $queueArguments = array_merge([
+                    'x-dead-letter-exchange'    => $destinationExchange,
+                    'x-dead-letter-routing-key' => $destination,
+                    'x-message-ttl'             => $delay * 1000,
+                ], (array)$this->configQueue['arguments']);
+            
             $this->channel->queue_declare(
                 $name,
                 $this->configQueue['passive'],
@@ -275,11 +283,7 @@ class RabbitMQQueue extends Queue implements QueueContract
                 $this->configQueue['exclusive'],
                 $this->configQueue['auto_delete'],
                 false,
-                new AMQPTable([
-                    'x-dead-letter-exchange'    => $destinationExchange,
-                    'x-dead-letter-routing-key' => $destination,
-                    'x-message-ttl'             => $delay * 1000,
-                ])
+                new AMQPTable($queueArguments)
             );
         }
 

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -231,7 +231,7 @@ class RabbitMQQueue extends Queue implements QueueContract
                 $this->configQueue['exclusive'],
                 $this->configQueue['auto_delete'],
                 false,
-                $this->configQueue['arguments']
+                new AMQPTable($this->configQueue['arguments'])
             );
 
             // bind queue to the exchange

--- a/tests/RabbitMQConnectorTest.php
+++ b/tests/RabbitMQConnectorTest.php
@@ -25,7 +25,7 @@ class RabbitMQConnectorTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
-                'arguments'   => [],
+                'arguments'   => null,
             ],
             'exchange_params' => [
                 'name'        => null,

--- a/tests/RabbitMQConnectorTest.php
+++ b/tests/RabbitMQConnectorTest.php
@@ -25,6 +25,7 @@ class RabbitMQConnectorTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
+                'arguments'   => false,
             ],
             'exchange_params' => [
                 'name'        => null,

--- a/tests/RabbitMQConnectorTest.php
+++ b/tests/RabbitMQConnectorTest.php
@@ -25,7 +25,7 @@ class RabbitMQConnectorTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
-                'arguments'   => false,
+                'arguments'   => [],
             ],
             'exchange_params' => [
                 'name'        => null,

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -4,6 +4,7 @@ use Illuminate\Container\Container;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Wire\AMQPTable;
 use PHPUnit\Framework\TestCase;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 
@@ -31,7 +32,7 @@ class RabbitMQQueueTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
-                'arguments'   => false,
+                'arguments'   => [],
             ],
             'exchange_params' => [
                 'name'        => 'exchange_name',
@@ -83,7 +84,7 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue_params']['exclusive'],
             $this->config['queue_params']['auto_delete'],
             false,
-            $this->config['queue_params']['arguments']
+            Mockery::any()
         )->once();
 
         $this->channel->shouldReceive('queue_bind')->with(
@@ -155,7 +156,7 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue_params']['exclusive'],
             $this->config['queue_params']['auto_delete'],
             false,
-            $this->config['queue_params']['arguments']
+            Mockery::any()
         )->once();
 
         $this->channel->shouldReceive('queue_bind')->with(

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -32,7 +32,7 @@ class RabbitMQQueueTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
-                'arguments'   => [],
+                'arguments'   => null,
             ],
             'exchange_params' => [
                 'name'        => 'exchange_name',

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -31,6 +31,7 @@ class RabbitMQQueueTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
+                'arguments'   => false,
             ],
             'exchange_params' => [
                 'name'        => 'exchange_name',
@@ -80,7 +81,9 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue_params']['passive'],
             $this->config['queue_params']['durable'],
             $this->config['queue_params']['exclusive'],
-            $this->config['queue_params']['auto_delete']
+            $this->config['queue_params']['auto_delete'],
+            false,
+            $this->config['queue_params']['arguments']
         )->once();
 
         $this->channel->shouldReceive('queue_bind')->with(
@@ -150,7 +153,9 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue_params']['passive'],
             $this->config['queue_params']['durable'],
             $this->config['queue_params']['exclusive'],
-            $this->config['queue_params']['auto_delete']
+            $this->config['queue_params']['auto_delete'],
+            false,
+            $this->config['queue_params']['arguments']
         )->once();
 
         $this->channel->shouldReceive('queue_bind')->with(


### PR DESCRIPTION
This PR adds config for additional queue arguments.

This arguments can be any of: `x-message-ttl`, `x-max-length`, ... See [docs](https://www.rabbitmq.com/maxlength.html) for these options. They are also listed in rabbitmq management web under the "Create new queue" command.

Since this options are key/value pairs I choose json notation in `.env` file (ENV() doesnt support arrays, just strings).

Please comment if there's anything you want me to change. I've changed tests and they all pass ok.