### PR TITLE
Added SSL support for the package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,25 @@ php:
   - 7.0
   - 7.1
 
+env:
+  - RABBITMQ_CONFIG_FILE="/tmp/rabbitmq.config" SSL_CAFILE="/tmp/rootCA.pem
+
 services:
   - rabbitmq
 
 before_script:
   - COMPOSER_DISCARD_CHANGES=1 composer update --prefer-dist --no-interaction --no-suggest
+  - sed -i 's/<env name="SSL_CAFILE" value="\/path_to_your_ca_file"\/>/<env name="SSL_CAFILE" value="\/tmp\/rootCA.pem"\/>/g' phpunit.xml.dist
+  - openssl genrsa -out /tmp/rootCA.key 2048
+  - openssl req -x509 -new -nodes -key /tmp/rootCA.key -sha256 -days 1024 -out /tmp/rootCA.pem  -subj "/C=US/ST=Arizona/L=Scottsdale/O=Example Company Inc./CN=127.0.0.1"
+  - openssl genrsa -out /tmp/device.key 2048
+  - openssl req -new -key /tmp/device.key -out /tmp/device.csr -subj "/C=US/ST=Arizona/L=Scottsdale/O=Example Company Inc./CN=127.0.0.1"
+  - openssl x509 -req -in /tmp/device.csr -CA /tmp/rootCA.pem -CAkey /tmp/rootCA.key -CAcreateserial -out /tmp/device.crt -days 500 -sha256
+  - sudo service rabbitmq-server stop
+  - echo "[{rabbit,[{ssl_listeners, [5671]},{ssl_options,[{cacertfile,\"/tmp/rootCA.pem\"},{certfile,\"/tmp/rootCA.pem\"},{keyfile,\"/tmp/rootCA.key\"},{verify,verify_none},{fail_if_no_peer_cert,false}]}]}]." > /tmp/rabbitmq.config
+  - cp /tmp/rabbitmq.config /tmp/rabbitmq.config.config
+  - sudo rabbitmq-server &
+  - sleep 10
+
 script:
   - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 php:
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 before_script:
   - COMPOSER_DISCARD_CHANGES=1 composer update --prefer-dist --no-interaction --no-suggest
-  - sed -i 's/<env name="SSL_CAFILE" value="\/path_to_your_ca_file"\/>/<env name="SSL_CAFILE" value="\/tmp\/rootCA.pem"\/>/g' phpunit.xml.dist
+  - sed -i 's/<env name="RABBITMQ_SSL_CAFILE" value="\/path_to_your_ca_file"\/>/<env name="SSL_CAFILE" value="\/tmp\/rootCA.pem"\/>/g' phpunit.xml.dist
   - openssl genrsa -out /tmp/rootCA.key 2048
   - openssl req -x509 -new -nodes -key /tmp/rootCA.key -sha256 -days 1024 -out /tmp/rootCA.pem  -subj "/C=US/ST=Arizona/L=Scottsdale/O=Example Company Inc./CN=127.0.0.1"
   - openssl genrsa -out /tmp/device.key 2048

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 before_script:
   - COMPOSER_DISCARD_CHANGES=1 composer update --prefer-dist --no-interaction --no-suggest
-  - sed -i 's/<env name="RABBITMQ_SSL_CAFILE" value="\/path_to_your_ca_file"\/>/<env name="SSL_CAFILE" value="\/tmp\/rootCA.pem"\/>/g' phpunit.xml.dist
+  - sed -i 's/<env name="RABBITMQ_SSL_CAFILE" value="\/path_to_your_ca_file"\/>/<env name="RABBITMQ_SSL_CAFILE" value="\/tmp\/rootCA.pem"\/>/g' phpunit.xml.dist
   - openssl genrsa -out /tmp/rootCA.key 2048
   - openssl req -x509 -new -nodes -key /tmp/rootCA.key -sha256 -days 1024 -out /tmp/rootCA.pem  -subj "/C=US/ST=Arizona/L=Scottsdale/O=Example Company Inc./CN=127.0.0.1"
   - openssl genrsa -out /tmp/device.key 2048

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - 7.1
 
 env:
-  - RABBITMQ_CONFIG_FILE="/tmp/rabbitmq.config" SSL_CAFILE="/tmp/rootCA.pem
+  - RABBITMQ_CONFIG_FILE="/tmp/rabbitmq.config"
+  - SSL_CAFILE="/tmp/rootCA.pem
 
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ php:
   - 7.1
 
 env:
-  - RABBITMQ_CONFIG_FILE="/tmp/rabbitmq.config"
-  - SSL_CAFILE="/tmp/rootCA.pem
+  - RABBITMQ_CONFIG_FILE="/tmp/rabbitmq.config" SSL_CAFILE="/tmp/rootCA.pem
 
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ RABBITMQ_QUEUE=queue_name
 3. Optionally: if you want to to use an SSL connection, add these properties to the `.env` with proper values:
 ```
 RABBITMQ_SSL=true
-
-SSL_CAFILE=/path/to/your/ca/cacert.pem
-SSL_LOCALCERT=
-SSL_PASSPHRASE=
-SSL_KEY=
+RABBITMQ_SSL_CAFILE=/path_to_your_ca_file
+RABBITMQ_SSL_LOCALCERT=
+RABBITMQ_SSL_PASSPHRASE=
+RABBITMQ_SSL_KEY=
 ```
 
 Using an SSL connection will also require to configure your RabbitMQ to enable SSL. More details can be founds here: https://www.rabbitmq.com/ssl.html

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ RABBITMQ_PASSWORD=guest
 RABBITMQ_QUEUE=queue_name
 ```
 
+3. Optionally: if you want to to use an SSL connection, add these properties to the `.env` with proper values:
+```
+RABBITMQ_SSL=true
+
+SSL_CAFILE=/path/to/your/ca/cacert.pem
+SSL_LOCALCERT=
+SSL_PASSPHRASE=
+SSL_KEY=
+```
+
+Using an SSL connection will also require to configure your RabbitMQ to enable SSL. More details can be founds here: https://www.rabbitmq.com/ssl.html
+
 #### Usage
 
 Once you completed the configuration you can use Laravel Queue API. If you used other queue drivers you do not need to change anything else. If you do not know how to use Queue API, please refer to the official Laravel documentation: http://laravel.com/docs/queues

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -60,10 +60,10 @@ return [
      */
     'ssl_params' => [
         'ssl_on'        => env('RABBITMQ_SSL', false),
-        'cafile'        => env('SSL_CAFILE', null),
-        'local_cert'    => env('SSL_LOCALCERT', null),
-        'verify_peer'   => env('SSL_VERIFY_PEER', true),
-        'passphrase'    => env('SSL_PASSPHRASE', null),
+        'cafile'        => env('RABBITMQ_SSL_CAFILE', null),
+        'local_cert'    => env('RABBITMQ_SSL_LOCALCERT', null),
+        'verify_peer'   => env('RABBITMQ_SSL_VERIFY_PEER', true),
+        'passphrase'    => env('RABBITMQ_SSL_PASSPHRASE', null),
     ]
 
 ];

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -55,4 +55,15 @@ return [
      */
     'sleep_on_error' => env('RABBITMQ_ERROR_SLEEP', 5),
 
+    /*
+     * Optional SSL params if an SSL connection is used
+     */
+    'ssl_params' => [
+        'ssl_on'        => env('RABBITMQ_SSL', false),
+        'cafile'        => env('SSL_CAFILE', null),
+        'local_cert'    => env('SSL_LOCALCERT', null),
+        'verify_peer'   => env('SSL_VERIFY_PEER', true),
+        'passphrase'    => env('SSL_PASSPHRASE', null),
+    ]
+
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
         <env name="HOST" value="127.0.0.1"/>
         <env name="PORT" value="5672"/>
         <env name="PORT_SSL" value="5671"/>
-        <env name="SSL_CAFILE" value="/path_to_your_ca_file"/>
+        <env name="RABBITMQ_SSL_CAFILE" value="/path_to_your_ca_file"/>
     </php>
     <filter>
         <whitelist>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,8 @@
     <php>
         <env name="HOST" value="127.0.0.1"/>
         <env name="PORT" value="5672"/>
+        <env name="PORT_SSL" value="5671"/>
+        <env name="SSL_CAFILE" value="/path_to_your_ca_file"/>
     </php>
     <filter>
         <whitelist>

--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -5,6 +5,7 @@ namespace VladimirYuldashev\LaravelQueueRabbitMQ;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\ServiceProvider;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnector;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnectorSSL;
 
 class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
 {
@@ -29,7 +30,12 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
     {
         /** @var QueueManager $queue */
         $queue = $this->app['queue'];
-        $connector = new RabbitMQConnector();
+        
+        if ($this->app['config']['rabbitmq']['ssl_params']['ssl_on'] === true) {
+            $connector = new RabbitMQConnectorSSL();
+        } else {
+            $connector = new RabbitMQConnector();
+        }
 
         $queue->stopping(function () use ($connector) {
             $connector->connection()->close();

--- a/src/Queue/Connectors/RabbitMQConnectorSSL.php
+++ b/src/Queue/Connectors/RabbitMQConnectorSSL.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors;
+
+use Illuminate\Queue\Connectors\ConnectorInterface;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class RabbitMQConnectorSSL implements ConnectorInterface
+{
+    /** @var AMQPSSLConnection */
+    private $connection;
+
+    /**
+     * Establish a queue connection.
+     *
+     * @param array $config
+     *
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        // Remove null values from the SSL config
+        foreach ($config['ssl_params'] as $idx => $option) {
+            if ($option === null || empty($option)) {
+                unset($config['ssl_params'][$idx]);
+            }
+        }
+
+        // Create connection with AMQP
+        $this->connection = new AMQPSSLConnection(
+            $config['host'],
+            $config['port'],
+            $config['login'],
+            $config['password'],
+            $config['vhost'],
+            $config['ssl_params']
+        );
+
+        return new RabbitMQQueue(
+            $this->connection,
+            $config
+        );
+    }
+
+    public function connection()
+    {
+        return $this->connection;
+    }
+}

--- a/tests/RabbitMQConnectorSSLTest.php
+++ b/tests/RabbitMQConnectorSSLTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+use PHPUnit\Framework\TestCase;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connectors\RabbitMQConnectorSSL;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class RabbitMQConnectorSSLTest extends TestCase
+{
+    public function test_connect()
+    {
+        $config = [
+            'host'     => getenv('HOST'),
+            'port'     => getenv('PORT_SSL'),
+            'login'    => 'guest',
+            'password' => 'guest',
+            'vhost'    => '/',
+
+            'queue'              => 'queue_name',
+            'exchange_declare'   => true,
+            'queue_declare_bind' => true,
+
+            'queue_params' => [
+                'passive'     => false,
+                'durable'     => true,
+                'exclusive'   => false,
+                'auto_delete' => false,
+                'arguments'   => null,
+            ],
+            'exchange_params' => [
+                'name'        => null,
+                'type'        => 'direct',
+                'passive'     => false,
+                'durable'     => true,
+                'auto_delete' => false,
+            ],
+            'ssl_params' => [
+                'cafile'        => getenv('SSL_CAFILE')
+            ]
+        ];
+
+        $connector = new RabbitMQConnectorSSL();
+        $queue = $connector->connect($config);
+
+        $this->assertInstanceOf(RabbitMQQueue::class, $queue);
+        $this->assertInstanceOf(AMQPSSLConnection::class, $connector->connection());
+    }
+}

--- a/tests/RabbitMQConnectorSSLTest.php
+++ b/tests/RabbitMQConnectorSSLTest.php
@@ -35,7 +35,7 @@ class RabbitMQConnectorSSLTest extends TestCase
                 'auto_delete' => false,
             ],
             'ssl_params' => [
-                'cafile'        => getenv('SSL_CAFILE')
+                'cafile'        => getenv('RABBITMQ_SSL_CAFILE')
             ]
         ];
 


### PR DESCRIPTION
It took me a while to figure out how to make Travis work with my changes. 
There's a bug in RabbitMQ which requires to have 2 identical config files (with an additional .config appendix) if you want to use custom configs so in the build there's a line which makes a copy of the main file.

Also, for some reason RabbitMQ doesn't want to use custom configs if started by:
sudo service rabbitmq-server start
so it must be started manually as a background process.

Sudo is required to stop the original RabbitMQ service so I had to remove that line which disables sudo from the Travis configuration file.