### PR TITLE
[5.5]Expose no_ack parameter

### DIFF
--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -40,6 +40,7 @@ return [
         'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
         'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
         'arguments'   => env('RABBITMQ_QUEUE_ARGUMENTS'),
+        'no_ack'      => env('RABBITMQ_QUEUE_NOACK', false)
     ],
     'exchange_params' => [
         'name' => env('RABBITMQ_EXCHANGE_NAME'),

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -120,7 +120,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             $this->declareQueue($queue);
 
             // get envelope
-            $message = $this->channel->basic_get($queue);
+            $message = $this->channel->basic_get($queue, $this->queueParameters['no_ack']);
 
             if ($message instanceof AMQPMessage) {
                 return new RabbitMQJob(

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -44,8 +44,8 @@ class RabbitMQQueue extends Queue implements QueueContract
         $this->connection = $connection;
         $this->defaultQueue = $config['queue'];
         $this->queueParameters = $config['queue_params'];
-        $this->queueParameters['no_ack'] = isset($this->queueParameters['no_ack']) 
-            ? $this->queueParameters['no_ack'] 
+        $this->queueParameters['no_ack'] = isset($this->queueParameters['no_ack'])
+            ? $this->queueParameters['no_ack']
             : false;
         $this->queueArguments = isset($this->queueParameters['arguments']) ? json_decode($this->queueParameters['arguments'], true) : [];
         $this->configExchange = $config['exchange_params'];

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -44,6 +44,9 @@ class RabbitMQQueue extends Queue implements QueueContract
         $this->connection = $connection;
         $this->defaultQueue = $config['queue'];
         $this->queueParameters = $config['queue_params'];
+        $this->queueParameters['no_ack'] = isset($this->queueParameters['no_ack']) 
+            ? $this->queueParameters['no_ack'] 
+            : false;
         $this->queueArguments = isset($this->queueParameters['arguments']) ? json_decode($this->queueParameters['arguments'], true) : [];
         $this->configExchange = $config['exchange_params'];
         $this->declareExchange = $config['exchange_declare'];

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -172,7 +172,10 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue']
         )->once();
 
-        $this->channel->shouldReceive('basic_get')->with($this->config['queue'])->andReturn($message)->once();
+        $this->channel->shouldReceive('basic_get')->with(
+            $this->config['queue'],
+            $this->config['queue_params']['no_ack']
+        )->andReturn($message)->once();
 
         /** @var Mock|mixed $container */
         $container = Mockery::mock(Container::class);

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -39,6 +39,7 @@ class RabbitMQQueueTest extends TestCase
                 'exclusive' => false,
                 'auto_delete' => false,
                 'arguments' => null,
+                'no_ack' => false,
             ],
             'exchange_params' => [
                 'name' => 'exchange_name',


### PR DESCRIPTION
Sometimes we need a task to be consumed once we get it from queue, so it's better to expose the `no_ack` parameter to us.