### PR TITLE
[5.4]Expose no_ack parameter

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -54,6 +54,9 @@ class RabbitMQQueue extends Queue implements QueueContract
         $this->connection = $amqpConnection;
         $this->defaultQueue = $config['queue'];
         $this->configQueue = $config['queue_params'];
+        $this->configQueue['no_ack'] = isset($config['queue_params']['no_ack'])
+            ? $config['queue_params']['no_ack']
+            : false;
         $this->configExchange = $config['exchange_params'];
         $this->declareExchange = $config['exchange_declare'];
         $this->declareBindQueue = $config['queue_declare_bind'];

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -164,7 +164,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             $this->declareQueue($queue);
 
             // get envelope
-            $message = $this->channel->basic_get($queue);
+            $message = $this->channel->basic_get($queue, $this->configQueue['no_ack']);
 
             if ($message instanceof AMQPMessage) {
                 return new RabbitMQJob(

--- a/src/config/rabbitmq.php
+++ b/src/config/rabbitmq.php
@@ -29,6 +29,7 @@ return [
         'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
         'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
         'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
+        'no_ack'      => env('RABBITMQ_QUEUE_NOACK', false),
     ],
     'exchange_params' => [
         'name' => env('RABBITMQ_EXCHANGE_NAME', null),

--- a/src/examples/queue.php
+++ b/src/examples/queue.php
@@ -94,6 +94,7 @@ return [
                 'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
                 'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
                 'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
+                'no_ack'      => env('RABBITMQ_QUEUE_NOACK', false),
             ],
 
             'exchange_params' => [

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -159,7 +159,10 @@ class RabbitMQQueueTest extends TestCase
             $this->config['queue']
         )->once();
 
-        $this->channel->shouldReceive('basic_get')->with($this->config['queue'])->andReturn($message)->once();
+        $this->channel->shouldReceive('basic_get')->with(
+            $this->config['queue'],
+            $this->config['queue_params']['no_ack']
+        )->andReturn($message)->once();
 
         $this->queue->setContainer(Mockery::mock(Container::class));
         $this->queue->pop();

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -31,6 +31,7 @@ class RabbitMQQueueTest extends TestCase
                 'durable'     => true,
                 'exclusive'   => false,
                 'auto_delete' => false,
+                'no_ack'      => false,
             ],
             'exchange_params' => [
                 'name'        => 'exchange_name',


### PR DESCRIPTION
Sometimes we need a task to be consumed once we get it from queue, so it's better to expose the no_ack parameter to us.