### PR TITLE
Allow reconnects

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -173,6 +173,17 @@ class RabbitMQQueue extends Queue implements QueueContract
         $this->correlationId = $id;
     }
 
+    /**
+     * Restarts the connection
+     *
+     * @return void
+     */
+    public function reconnect()
+    {
+        $this->connection->reconnect();
+        $this->channel = $this->getChannel();
+    }
+
     private function getQueueName(string $queue = null): string
     {
         return $queue ?: $this->defaultQueue;

--- a/tests/RabbitMQQueueTest.php
+++ b/tests/RabbitMQQueueTest.php
@@ -193,4 +193,11 @@ class RabbitMQQueueTest extends TestCase
 
         $this->queue->setCorrelationId($id);
     }
+
+    public function testReconnect()
+    {
+        $this->connection->shouldReceive('reconnect');
+        $this->connection->shouldReceive('channel')->andReturn(Mockery::mock(AMQPChannel::class));
+        $this->queue->reconnect();
+    }
 }


### PR DESCRIPTION
Sometimes when running in a long running job, the queue connection will fail and it becomes impossible to push new messages.

This allows the user to re-create the connection when that happens. This way a call to `push` or `pushRaw` can be wrapped in `\retry(...)` with a reconnect to avoid dropped messages or a full process restart.