### PR TITLE
Fix chained jobs attempts

### DIFF
--- a/src/Queue/Jobs/RabbitMQJob.php
+++ b/src/Queue/Jobs/RabbitMQJob.php
@@ -107,7 +107,6 @@ class RabbitMQJob extends Job implements JobContract
         parent::release($delay);
 
         $this->delete();
-        $this->connection->setAttempts($this->attempts() + 1);
 
         $body = $this->payload();
 
@@ -122,11 +121,7 @@ class RabbitMQJob extends Job implements JobContract
 
         $data = $body['data'];
 
-        if ($delay > 0) {
-            $this->connection->later($delay, $job, $data, $this->getQueue());
-        } else {
-            $this->connection->push($job, $data, $this->getQueue());
-        }
+        $this->connection->release($delay, $job, $data, $this->getQueue(), $this->attempts() + 1);
     }
 
     /**


### PR DESCRIPTION
There are Job1 and Job2.
Added to the queue using Job1::withChain([new Job2 ()])->dispatch();

If Job1 $tries = 2 and Job2 $tries = 1. Then if the second attempt is successful for Job1, Job2 will not be executed because $ job->attempts () for Job2 will immediately return 2.

And if $tries are the same, then the number of attempts for the next will be less by the number of failures in the chain than should be.