### PR TITLE
Use basic consume

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "illuminate/database": "5.5.*",
     "illuminate/support": "5.5.*",
     "illuminate/queue": "5.5.*",
-    "enqueue/amqp-lib": "0.8.5",
+    "enqueue/amqp-lib": "^0.8.15",
     "queue-interop/amqp-interop": "^0.7"
   },
   "require-dev": {

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -93,4 +93,15 @@ return [
         'passphrase' => env('RABBITMQ_SSL_PASSPHRASE', null),
     ],
 
+    'receive' => [
+        /**
+         * Use basic_consume by default which will block and not poll
+         */
+        'method' => env('RABBITMQ_RECEIVE_METHOD', 'basic_consume'),
+
+        /**
+         * The timeout (in milliseconds) to block and wait for a message
+         */
+        'timeout' => env('RABBITMQ_RECEIVE_TIMEOUT', 5000),
+    ],
 ];

--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -57,6 +57,7 @@ class RabbitMQConnector implements ConnectorInterface
             'ssl_cert' => $config['ssl_params']['local_cert'],
             'ssl_key' => $config['ssl_params']['local_key'],
             'ssl_passphrase' => $config['ssl_params']['passphrase'],
+            'receive_method' => isset($config['receive']) ? $config['receive']['method'] : 'basic_get',
         ]);
 
         if ($factory instanceof DelayStrategyAware) {

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -134,7 +134,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             // create the consumer once and cache it
             $consumer = $this->createConsumerOnce($queue);
 
-            if (isset($this->receiveConfig['method']) AND $this->receiveConfig['method'] == 'basic_consume') {
+            if (isset($this->receiveConfig['method']) and $this->receiveConfig['method'] == 'basic_consume') {
                 $message = $consumer->receive($this->receiveConfig['timeout']);
             } else {
                 $message = $consumer->receiveNoWait();
@@ -280,5 +280,4 @@ class RabbitMQQueue extends Queue implements QueueContract
         // Sleep so that we don't flood the log file
         sleep($this->sleepOnError);
     }
-
 }

--- a/tests/Queue/Connectors/RabbitMQConnectorTest.php
+++ b/tests/Queue/Connectors/RabbitMQConnectorTest.php
@@ -74,6 +74,7 @@ class RabbitMQConnectorTest extends TestCase
                 'ssl_cert' => 'theLocalCert',
                 'ssl_key' => 'theLocalKey',
                 'ssl_passphrase' => 'thePassPhrase',
+                'receive_method' => 'basic_get',
             ], $config);
         };
 


### PR DESCRIPTION
By using basic_consume, a queue worker can respond very quickly to a queued message.

This does not poll the rabbitmq server.  Instead it blocks with an open connection to the rabbitmq server.

This is a solution for #165.