### PR TITLE
change method visibility to allow extension

### DIFF
--- a/src/Queue/Jobs/RabbitMQJob.php
+++ b/src/Queue/Jobs/RabbitMQJob.php
@@ -155,7 +155,7 @@ class RabbitMQJob extends Job implements JobContract
      *
      * @return mixed
      */
-    private function unserialize(array $body)
+    protected function unserialize(array $body)
     {
         try {
             /** @noinspection UnserializeExploitsInspection */

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -21,14 +21,14 @@ class RabbitMQQueue extends Queue implements QueueContract
     protected $queueOptions;
     protected $exchangeOptions;
 
-    private $declaredExchanges = [];
-    private $declaredQueues = [];
+    protected $declaredExchanges = [];
+    protected $declaredQueues = [];
 
     /**
      * @var AmqpContext
      */
-    private $context;
-    private $correlationId;
+    protected $context;
+    protected $correlationId;
 
     public function __construct(AmqpContext $context, array $config)
     {
@@ -182,7 +182,7 @@ class RabbitMQQueue extends Queue implements QueueContract
      *
      * @return array [Interop\Amqp\AmqpQueue, Interop\Amqp\AmqpTopic]
      */
-    private function declareEverything(string $queueName = null): array
+    protected function declareEverything(string $queueName = null): array
     {
         $queueName = $queueName ?: $this->queueName;
         $exchangeName = $this->exchangeOptions['name'] ?: $queueName;


### PR DESCRIPTION
Hey :wave:! I'm currently using this package with Laravel and its working fantastically. I'm in the process of trying to get it to work with ![Laravel Horizon](https://github.com/laravel/horizon), and I think I've come pretty close. 

Currently, I'm extending the queue and the job, but because some of the methods and properties are private, i'm having to copy and paste blocks of code to change their visibility.

Can these changes be merged in order to extend the functionality of the Job and the Queue? The Laravel\Horizon\RedisQueue extends the standard Illuminate\Queue\RedisQueue and wraps Horizon Events around queue interactions. Changing the visibility of the methods here would allow us to do the same thing with this RabbitMQ impemntation.

Thanks