### PR TITLE
support basic_consume and basic_get connection

### DIFF
--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -70,6 +70,19 @@ return [
             'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
             'arguments' => env('RABBITMQ_QUEUE_ARGUMENTS'),
         ],
+
+        'connection' => [
+            /**
+             * Currently support 2 values:
+             *     'basic_get' (by default) : poll, not block 
+             *     'basic_consume'          : block and not poll
+             */
+            'method' => env('RABBITMQ_CONNECTION_METHOD', 'basic_get'),
+            /**
+             * The timeout (in milliseconds) to block and wait for a message
+             */
+            'timeout' => env('RABBITMQ_CONNECTION_TIMEOUT', 5000),
+        ],
     ],
 
     /*

--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -58,6 +58,7 @@ class RabbitMQConnector implements ConnectorInterface
             'ssl_cert' => $config['ssl_params']['local_cert'],
             'ssl_key' => $config['ssl_params']['local_key'],
             'ssl_passphrase' => $config['ssl_params']['passphrase'],
+            'connection_method' => isset($config['options']['connection']) ? $config['options']['connection']['method'] : 'basic_get',
         ]);
 
         if ($factory instanceof DelayStrategyAware) {

--- a/tests/Queue/Connectors/RabbitMQConnectorTest.php
+++ b/tests/Queue/Connectors/RabbitMQConnectorTest.php
@@ -74,6 +74,7 @@ class RabbitMQConnectorTest extends TestCase
                 'ssl_cert' => 'theLocalCert',
                 'ssl_key' => 'theLocalKey',
                 'ssl_passphrase' => 'thePassPhrase',
+                'connection_method' => 'basic_get',
             ], $config);
         };
 
@@ -183,6 +184,11 @@ class RabbitMQConnectorTest extends TestCase
                     'exclusive' => false,
                     'auto_delete' => false,
                     'arguments' => '[]',
+                ],
+
+                'connection' => [
+                    'method' => 'basic_get',
+                    'timeout' => 5000,
                 ],
             ],
             'sleep_on_error' => env('RABBITMQ_ERROR_SLEEP', 5),


### PR DESCRIPTION
Thanks to PR #172 from @deweller, I create new PR based on latest master branch, please help to review again.

1. support basic_consume and basic_get connection
2. use cache for consumer and declarations
3. fix unit test