### PR TITLE
queue: accept custom RabbitMQQueue class

### DIFF
--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -86,6 +86,10 @@ class RabbitMQConnector implements ConnectorInterface
             return new HorizonRabbitMQQueue($context, $config);
         }
 
+        if (class_exists($worker)) {
+            return new $worker($context, $config);
+        }
+
         throw new InvalidArgumentException('Invalid worker.');
     }
 }


### PR DESCRIPTION
Add the ability to change Queue class

queue.php configuration file can be
`'worker' => \App\Providers\Foo::class,`

and Foo class should be something like

```php
/**
 * Class Foo.
 */
class Foo extends RabbitMQQueue
{
}
```
