### PR TITLE
Making RabbitMQQueue::declareEverything() public

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -206,7 +206,7 @@ class RabbitMQQueue extends Queue implements QueueContract
      *
      * @return array [Interop\Amqp\AmqpQueue, Interop\Amqp\AmqpTopic]
      */
-    protected function declareEverything(string $queueName = null): array
+    public function declareEverything(string $queueName = null): array
     {
         $queueName = $this->getQueueName($queueName);
         $exchangeName = $this->exchangeOptions['name'] ?: $queueName;


### PR DESCRIPTION
So we can use rabbit queue/topic instance outside the Queue.