### PR TITLE
Fix return type of getJobId() method

### DIFF
--- a/src/Queue/Jobs/RabbitMQJob.php
+++ b/src/Queue/Jobs/RabbitMQJob.php
@@ -135,9 +135,9 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string
+     * @return string|null
      */
-    public function getJobId(): string
+    public function getJobId(): ?string
     {
         return $this->message->getCorrelationId();
     }


### PR DESCRIPTION
This commit fixes the following error which could occur when correlation ID is not present in a message:

> Return value of VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Jobs\RabbitMQJob::getJobId() must be of the type string, null returned

The return type of _getJobId()_ method should allow null values because of calling _getCorrelationId()_ from _Interop\Queue\Message_ interface which also has a nullable return type:

```php
<?php

namespace VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Jobs;

class RabbitMQJob extends Job implements JobContract
{
    // ...
    public function getJobId(): string // <- return type isn't nullabe
    {
        return $this->message->getCorrelationId();
    }
    // ...
}
```

```php
<?php

namespace Interop\Queue;

interface Message
{
    // ...
    public function getCorrelationId(): ?string; // <- return type is nullabe
    // ...
}
```