### PR TITLE
Fix #277

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -201,7 +201,7 @@ class RabbitMQQueue extends Queue implements QueueContract
     public function declareEverything(string $queueName = null): array
     {
         $queueName = $this->getQueueName($queueName);
-        $exchangeName = $this->exchangeOptions['name'] ?: $queueName;
+        $exchangeName = is_string($this->exchangeOptions['name'] ?? null) ? $this->exchangeOptions['name'] : $queueName;
 
         $topic = $this->context->createTopic($exchangeName);
         $topic->setType($this->exchangeOptions['type']);


### PR DESCRIPTION
Attempt to fix issue https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/277.

Only defaults to the queue name if a non-string is supplied for the exchange name (ie: supplying `null` will use the queue name as the exchange name).