### PR TITLE
Add reconnect feature (master-branch).

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ return PhpCsFixer\Config::create()
         'blank_line_after_namespace' => true,
         'braces' => true,
         'class_definition' => true,
+        'concat_space' => ['spacing' => 'none'],
         'elseif' => true,
         'function_declaration' => true,
         'indentation_type' => true,

--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -15,6 +15,8 @@ use Interop\Amqp\AmqpConnectionFactory;
 use Interop\Amqp\AmqpConnectionFactory as InteropAmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
 use InvalidArgumentException;
+use LogicException;
+use ReflectionClass;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Horizon\Listeners\RabbitMQFailedEvent;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Horizon\RabbitMQQueue as HorizonRabbitMQQueue;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
@@ -41,34 +43,8 @@ class RabbitMQConnector implements ConnectorInterface
      */
     public function connect(array $config): Queue
     {
-        $factoryClass = Arr::get($config, 'factory_class', EnqueueAmqpConnectionFactory::class);
-
-        if (! class_exists($factoryClass) || ! (new \ReflectionClass($factoryClass))->implementsInterface(InteropAmqpConnectionFactory::class)) {
-            throw new \LogicException(sprintf('The factory_class option has to be valid class that implements "%s"', InteropAmqpConnectionFactory::class));
-        }
-
-        /** @var AmqpConnectionFactory $factory */
-        $factory = new $factoryClass([
-            'dsn' => Arr::get($config, 'dsn'),
-            'host' => Arr::get($config, 'host', '127.0.0.1'),
-            'port' => Arr::get($config, 'port', 5672),
-            'user' => Arr::get($config, 'login', 'guest'),
-            'pass' => Arr::get($config, 'password', 'guest'),
-            'vhost' => Arr::get($config, 'vhost', '/'),
-            'ssl_on' => Arr::get($config, 'ssl_params.ssl_on', false),
-            'ssl_verify' => Arr::get($config, 'ssl_params.verify_peer', true),
-            'ssl_cacert' => Arr::get($config, 'ssl_params.cafile'),
-            'ssl_cert' => Arr::get($config, 'ssl_params.local_cert'),
-            'ssl_key' => Arr::get($config, 'ssl_params.local_key'),
-            'ssl_passphrase' => Arr::get($config, 'ssl_params.passphrase'),
-        ]);
-
-        if ($factory instanceof DelayStrategyAware) {
-            $factory->setDelayStrategy(new RabbitMqDlxDelayStrategy());
-        }
-
         /** @var AmqpContext $context */
-        $context = $factory->createContext();
+        $context = self::createContext($config);
 
         $this->dispatcher->listen(WorkerStopping::class, function () use ($context) {
             $context->close();
@@ -91,5 +67,42 @@ class RabbitMQConnector implements ConnectorInterface
         }
 
         throw new InvalidArgumentException('Invalid worker.');
+    }
+
+    /**
+     * Create a context.
+     *
+     * @param  array  $config
+     * @return AmqpContext
+     */
+    public static function createContext(array $config): AmqpContext
+    {
+        $factoryClass = Arr::get($config, 'factory_class', EnqueueAmqpConnectionFactory::class);
+
+        if (! class_exists($factoryClass) || ! (new ReflectionClass($factoryClass))->implementsInterface(InteropAmqpConnectionFactory::class)) {
+            throw new LogicException(sprintf('The factory_class option has to be valid class that implements "%s"', InteropAmqpConnectionFactory::class));
+        }
+
+        /** @var AmqpConnectionFactory $factory */
+        $factory = new $factoryClass([
+            'dsn'            => Arr::get($config, 'dsn'),
+            'host'           => Arr::get($config, 'host', '127.0.0.1'),
+            'port'           => Arr::get($config, 'port', 5672),
+            'user'           => Arr::get($config, 'login', 'guest'),
+            'pass'           => Arr::get($config, 'password', 'guest'),
+            'vhost'          => Arr::get($config, 'vhost', '/'),
+            'ssl_on'         => Arr::get($config, 'ssl_params.ssl_on', false),
+            'ssl_verify'     => Arr::get($config, 'ssl_params.verify_peer', true),
+            'ssl_cacert'     => Arr::get($config, 'ssl_params.cafile'),
+            'ssl_cert'       => Arr::get($config, 'ssl_params.local_cert'),
+            'ssl_key'        => Arr::get($config, 'ssl_params.local_key'),
+            'ssl_passphrase' => Arr::get($config, 'ssl_params.passphrase'),
+        ]);
+
+        if ($factory instanceof DelayStrategyAware) {
+            $factory->setDelayStrategy(new RabbitMqDlxDelayStrategy());
+        }
+
+        return $factory->createContext();
     }
 }

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -10,6 +10,7 @@ use Interop\Amqp\AmqpMessage;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Exception\AMQPChannelClosedException;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -167,7 +168,7 @@ class RabbitMQQueue extends Queue implements QueueContract
                 $this->declaredExchanges = [];
                 $this->declaredQueues = [];
                 $this->context = RabbitMQConnector::createContext($this->config);
-            } catch (\Exception $e) {
+            } catch (Throwable $e) {
                 // Silent reconnect attempt.
             }
 


### PR DESCRIPTION
We had some problems with the queue worker(s) because they would got into "Broken pipe or closed connection" error flooding mode when the RabbitMQ cluster was restarted for maintenance.

We are currently fixing that by letting the (managed) workers crash by setting the RABBITMQ_ERROR_SLEEP=false Because they are managed they will start again when the cluster is back up.

To reproduce:

- start RabbitMQ
- start the queue worker
- stop and start RabbitMQ
- log gets flooded with "AMQP error while attempting pop: Broken pipe or closed connection"
- queue worker does not stop