### PR TITLE
Exchange type should be an option, not argument

### DIFF
--- a/src/Console/ExchangeDeclareCommand.php
+++ b/src/Console/ExchangeDeclareCommand.php
@@ -35,7 +35,7 @@ class ExchangeDeclareCommand extends Command
 
         $queue->declareExchange(
             $this->argument('name'),
-            $this->argument('type'),
+            $this->option('type'),
             (bool) $this->option('durable'),
             (bool) $this->option('auto-delete')
         );


### PR DESCRIPTION
In the Console/ExchangeDeclareCommand.php exchange type declared as an option, but used as argument.

```
tm@mo:/var/www$ php artisan rabbitmq:exchange-declare test --type=topic

The "type" argument does not exist.
```