### PR TITLE
Fix rabbitmq:queue-bind command

### DIFF
--- a/src/Console/QueueBindCommand.php
+++ b/src/Console/QueueBindCommand.php
@@ -12,7 +12,7 @@ class QueueBindCommand extends Command
                            {queue}
                            {exchange}
                            {connection=rabbitmq : The name of the queue connection to use}
-                           {--routing-key}';
+                           {--routing-key= : Bind queue to exchange via routing key}';
 
     protected $description = 'Bind queue to exchange';
 


### PR DESCRIPTION
In the Console/QueueBindCommand.php routing-key declared as an option with no acceptable value.
Fix needed.

```
tm@mo:/var/www$ php artisan rabbitmq:queue-bind test test --routing-key=test

The "--routing-key" option does not accept a value.
```