### PR TITLE
Allow to disable non-blocking mode

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -37,7 +37,7 @@ class ConsumeCommand extends WorkCommand
         $consumer->setConsumerTag($this->consumerTag());
         $consumer->setPrefetchSize((int) $this->option('prefetch-size'));
         $consumer->setPrefetchCount((int) $this->option('prefetch-count'));
-        $consumer->setNonBlocking(!$this->option('blocking'));
+        $consumer->setNonBlocking(! $this->option('blocking'));
 
         parent::handle();
     }

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -23,6 +23,7 @@ class ConsumeCommand extends WorkCommand
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}
+                            {--blocking : Use blocking mode to reduce CPU usage}
                            ';
 
     protected $description = 'Consume messages';
@@ -36,6 +37,7 @@ class ConsumeCommand extends WorkCommand
         $consumer->setConsumerTag($this->consumerTag());
         $consumer->setPrefetchSize((int) $this->option('prefetch-size'));
         $consumer->setPrefetchCount((int) $this->option('prefetch-count'));
+        $consumer->setNonBlocking(!$this->option('blocking'));
 
         parent::handle();
     }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -32,6 +32,9 @@ class Consumer extends Worker
     /** @var AMQPChannel */
     protected $channel;
 
+    /** @var bool */
+    protected $nonBlocking = true;
+
     public function setContainer(Container $value): void
     {
         $this->container = $value;
@@ -50,6 +53,11 @@ class Consumer extends Worker
     public function setPrefetchCount(int $value): void
     {
         $this->prefetchCount = $value;
+    }
+
+    public function setNonBlocking(bool $nonBlocking): void
+    {
+        $this->nonBlocking = $nonBlocking;
     }
 
     public function daemon($connectionName, $queue, WorkerOptions $options): void
@@ -108,7 +116,7 @@ class Consumer extends Worker
             // fire off this job for processing. Otherwise, we will need to sleep the
             // worker so no more jobs are processed until they should be processed.
             try {
-                $this->channel->wait(null, true, (int) $options->timeout);
+                $this->channel->wait(null, $this->nonBlocking, (int) $options->timeout);
             } catch (AMQPRuntimeException $exception) {
                 $this->exceptions->report($exception);
 


### PR DESCRIPTION
With non-blocking mode we have CPU usage ~100%.
So, lets declare an option for `rabbitmq:consume` command to toggle this behavior.

Actualy, I'd rather to set up `non_blocking=false` while channel is waiting, by default. But, maybe it's a BC breaking change.

`php artisan rabbitmq:consume` - current behavior (with non-blocking mode)
`php artisan rabbitmq:consume --blocking` - with blocking mode