### PR TITLE
When a job fails it tries to reject it twice.

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -154,23 +154,6 @@ class Consumer extends Worker
     }
 
     /**
-     * Mark the given job as failed if it has exceeded the maximum allowed attempts.
-     *
-     * @param string $connectionName
-     * @param Job|RabbitMQJob $job
-     * @param int $maxTries
-     * @param Exception $e
-     */
-    protected function markJobAsFailedIfWillExceedMaxAttempts($connectionName, $job, $maxTries, $e): void
-    {
-        parent::markJobAsFailedIfWillExceedMaxAttempts($connectionName, $job, $maxTries, $e);
-
-        if (! $job->isDeletedOrReleased()) {
-            $job->getRabbitMQ()->reject($job);
-        }
-    }
-
-    /**
      * Stop listening and bail out of the script.
      *
      * @param  int  $status


### PR DESCRIPTION
When a job fails in Consumer.php the override of function markJobAsFailedIfWillExceedMaxAttempts causes job to try to reject twice resulting failure on the consumer, due to false tag message.

This occurs only if the job running throw exception for some reason. Above fix remove that function. After that it works as expected.