### PR TITLE
Headers messages

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -178,7 +178,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         $this->declareQueue($destination, true, false, $this->getDelayQueueArguments($this->getQueue($queue), $ttl));
 
-        if (!$contentType) {
+        if (! $contentType) {
             $contentType = $this->getContentType([]);
         }
         if ($this->mustHeadersDefault()) {
@@ -703,7 +703,7 @@ class RabbitMQQueue extends Queue implements QueueContract
      */
     protected function mustHeadersDefault(): bool
     {
-        return !boolval(Arr::get($this->options, 'no_header_default') ?: false);
+        return ! boolval(Arr::get($this->options, 'no_header_default') ?: false);
     }
 
     /**
@@ -718,6 +718,7 @@ class RabbitMQQueue extends Queue implements QueueContract
         $headers['laravel'] = [
             'attempts' => $attempts,
         ];
+
         return $headers;
     }
 


### PR DESCRIPTION
Config no send "application_headers" : "laravel" => [ "attemps" => 0 ]. in message
```
        'rabbitmq' => [
            'options' => [
                'queue' => [
                    ...
                    'no_header_default' => true,
                ],
            ],
         ],
    ],
```


On send Message, set "content-type" and "headers"
```
        $connection = "rabbitmq";
        $payload = [
            "dataMessage" => "test-Message",
        ];
        $queue = "notifications.laravel";
        $options = [
            'content_type' => 'application/json',
            'headers' => [ "myHeader" => [ "key"=> "value" ] ],
        ];
        Queue::connection("rabbitmq")->pushRaw(json_encode($payload), $queue, $options);
```

or
```
        $connection = "rabbitmq";
        $payload = "plain-text-message;
        $queue = "notifications.laravel";
        $options = [
            'content_type' => 'application/text',
            'headers' => [ "myHeader" => [ "key"=> "value" ] ],
        ];
        Queue::connection("rabbitmq")->pushRaw(json_encode($payload), $queue, $options);
```