### PR TITLE
Remember exchanges once they have been verified

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -383,6 +383,8 @@ class RabbitMQQueue extends Queue implements QueueContract
             return;
         }
 
+        unset($this->exchanges[$name]);
+
         $this->channel->exchange_delete(
             $name,
             $unused

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -383,7 +383,8 @@ class RabbitMQQueue extends Queue implements QueueContract
             return;
         }
 
-        unset($this->exchanges[$name]);
+        $idx = array_search($name, $this->exchanges);
+        unset($this->exchanges[$idx]);
 
         $this->channel->exchange_delete(
             $name,

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -315,11 +315,16 @@ class RabbitMQQueue extends Queue implements QueueContract
      */
     public function isExchangeExists(string $exchange): bool
     {
+        if ($this->isExchangeDeclared($exchange)) {
+            return true;
+        }
         try {
             // create a temporary channel, so the main channel will not be closed on exception
             $channel = $this->connection->channel();
             $channel->exchange_declare($exchange, '', true);
             $channel->close();
+
+            $this->exchanges[] = $exchange;
 
             return true;
         } catch (AMQPProtocolChannelException $exception) {


### PR DESCRIPTION
We were having an issue when publishing a large number of messages: an initial job reads a bunch of data and pushes 1 outgoing job / item in the data.

When we do that, RabbitMQ's memory usage grows considerably and in the logs from rabbitmq, we see:

```
channel 1:
 operation basic.publish caused a connection exception channel_error: "expected 'channel.open'"
```

However once we have verified that the exchange exists once, there shouldn't be a need to verify if it still exists for every message that is being pushed. Instead, we can just mark that exchange as being known to exist for the life of this process and only check it once per exchange per PHP process.

According to https://github.com/ruby-amqp/bunny/issues/250 this would be rabbit becoming unable to generate new channel IDs