### PR TITLE
added support for blocking channel->wait

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -27,6 +27,7 @@ class ConsumeCommand extends WorkCommand
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}
+							{--non-blocking=true}
                            ';
 
     protected $description = 'Consume messages';
@@ -41,6 +42,7 @@ class ConsumeCommand extends WorkCommand
         $consumer->setConsumerTag($this->consumerTag());
         $consumer->setPrefetchSize((int) $this->option('prefetch-size'));
         $consumer->setPrefetchCount((int) $this->option('prefetch-count'));
+        $consumer->setNonblocking((bool) $this->option('non-blocking')=='false'?false:true);
 
         parent::handle();
     }


### PR DESCRIPTION
Using blocking call can speed up the latency for the queue processing significantly.