### PR TITLE
Fix missing rest option

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -23,6 +23,7 @@ class ConsumeCommand extends WorkCommand
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : Number of times to attempt a job before logging it failed}
+                            {--rest=0 : Number of seconds to rest between jobs}
                            
                             {--consumer-tag}
                             {--prefetch-size=0}


### PR DESCRIPTION
Added `rest` option to `ConsumeCommand` as Laravel 8.32 added `rest` option to `php artisan queue:work` command.