### PR TITLE
Add priority for jobs

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -25,7 +25,7 @@ class ConsumeCommand extends WorkCommand
                             {--tries=1 : Number of times to attempt a job before logging it failed}
                             {--rest=0 : Number of seconds to rest between jobs}
 
-                            {--max-priority=4}
+                            {--max-priority}
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -24,7 +24,8 @@ class ConsumeCommand extends WorkCommand
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : Number of times to attempt a job before logging it failed}
                             {--rest=0 : Number of seconds to rest between jobs}
-                           
+
+                            {--max-priority=4}
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}
@@ -40,6 +41,7 @@ class ConsumeCommand extends WorkCommand
         $consumer->setContainer($this->laravel);
         $consumer->setName($this->option('name'));
         $consumer->setConsumerTag($this->consumerTag());
+        $consumer->setMaxPriority((int) $this->option('max-priority'));
         $consumer->setPrefetchSize((int) $this->option('prefetch-size'));
         $consumer->setPrefetchCount((int) $this->option('prefetch-count'));
 

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -25,7 +25,7 @@ class ConsumeCommand extends WorkCommand
                             {--tries=1 : Number of times to attempt a job before logging it failed}
                             {--rest=0 : Number of seconds to rest between jobs}
 
-                            {--max-priority}
+                            {--max-priority=}
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}

--- a/src/Console/QueueDeclareCommand.php
+++ b/src/Console/QueueDeclareCommand.php
@@ -12,7 +12,7 @@ class QueueDeclareCommand extends Command
                            {name : The name of the queue to declare}
                            {connection=rabbitmq : The name of the queue connection to use}
                            {--durable=1}
-                           {--max-priority=4}
+                           {--max-priority}
                            {--auto-delete=0}';
 
     protected $description = 'Declare queue';
@@ -32,10 +32,13 @@ class QueueDeclareCommand extends Command
 
             return;
         }
+
+        $arguments = [];
         $maxPriority = (int) $this->option('max-priority');
-        $arguments = [
-            'x-max-priority' => $maxPriority,
-        ];
+        if ($maxPriority) {
+            $arguments['x-max-priority'] = $maxPriority;
+        }
+
         $queue->declareQueue(
             $this->argument('name'),
             (bool) $this->option('durable'),

--- a/src/Console/QueueDeclareCommand.php
+++ b/src/Console/QueueDeclareCommand.php
@@ -34,7 +34,7 @@ class QueueDeclareCommand extends Command
         }
         $maxPriority = (int) $this->option('max-priority');
         $arguments = [
-            'x-max-priority' => $maxPriority
+            'x-max-priority' => $maxPriority,
         ];
         $queue->declareQueue(
             $this->argument('name'),

--- a/src/Console/QueueDeclareCommand.php
+++ b/src/Console/QueueDeclareCommand.php
@@ -12,6 +12,7 @@ class QueueDeclareCommand extends Command
                            {name : The name of the queue to declare}
                            {connection=rabbitmq : The name of the queue connection to use}
                            {--durable=1}
+                           {--max-priority=4}
                            {--auto-delete=0}';
 
     protected $description = 'Declare queue';
@@ -31,11 +32,15 @@ class QueueDeclareCommand extends Command
 
             return;
         }
-
+        $maxPriority = (int) $this->option('max-priority');
+        $arguments = [
+            'x-max-priority' => $maxPriority
+        ];
         $queue->declareQueue(
             $this->argument('name'),
             (bool) $this->option('durable'),
-            (bool) $this->option('auto-delete')
+            (bool) $this->option('auto-delete'),
+            $arguments
         );
 
         $this->info('Queue declared successfully.');

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -93,7 +93,7 @@ class Consumer extends Worker
         $jobClass = $connection->getJobClass();
         $arguments = [];
         if ($this->maxPriority) {
-           $arguments['priority'] = ['I', $this->maxPriority];
+            $arguments['priority'] = ['I', $this->maxPriority];
         }
 
         $this->channel->basic_consume(

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -24,6 +24,9 @@ class Consumer extends Worker
     protected $prefetchSize;
 
     /** @var int */
+    protected $maxPriority;
+
+    /** @var int */
     protected $prefetchCount;
 
     /** @var AMQPChannel */
@@ -40,6 +43,11 @@ class Consumer extends Worker
     public function setConsumerTag(string $value): void
     {
         $this->consumerTag = $value;
+    }
+
+    public function setMaxPriority(int $value): void
+    {
+        $this->maxPriority = $value ?? 1;
     }
 
     public function setPrefetchSize(int $value): void
@@ -113,7 +121,9 @@ class Consumer extends Worker
                 if ($this->supportsAsyncSignals()) {
                     $this->resetTimeoutHandler();
                 }
-            }
+            },
+            null,
+            ['priority' => ['I', $this->maxPriority]]
         );
 
         while ($this->channel->is_consuming()) {

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -91,6 +91,10 @@ class Consumer extends Worker
         );
 
         $jobClass = $connection->getJobClass();
+        $arguments = [];
+        if ($this->maxPriority) {
+           $arguments['priority'] = ['I', $this->maxPriority];
+        }
 
         $this->channel->basic_consume(
             $queue,
@@ -123,7 +127,7 @@ class Consumer extends Worker
                 }
             },
             null,
-            ['priority' => ['I', $this->maxPriority]]
+            $arguments
         );
 
         while ($this->channel->is_consuming()) {

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -47,7 +47,7 @@ class Consumer extends Worker
 
     public function setMaxPriority(int $value): void
     {
-        $this->maxPriority = $value ?? 1;
+        $this->maxPriority = $value;
     }
 
     public function setPrefetchSize(int $value): void

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -542,8 +542,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             $properties['priority'] = $attempts;
         }
         $commandData = unserialize($currentPayload['data']['command']);
-        if(property_exists($commandData, 'priority'))
-        {
+        if(property_exists($commandData, 'priority')) {
             $properties['priority'] = $commandData->priority;
         }
         $message = new AMQPMessage($payload, $properties);

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -542,7 +542,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             $properties['priority'] = $attempts;
         }
         $commandData = unserialize($currentPayload['data']['command']);
-        if(property_exists($commandData, 'priority')) {
+        if (property_exists($commandData, 'priority')) {
             $properties['priority'] = $commandData->priority;
         }
         $message = new AMQPMessage($payload, $properties);

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -530,7 +530,6 @@ class RabbitMQQueue extends Queue implements QueueContract
         $properties = [
             'content_type' => 'application/json',
             'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
-            'priority' => 1,
         ];
 
         $currentPayload = json_decode($payload, true, 512);


### PR DESCRIPTION
Sometimes it is essential for a job to be consumed based on priority. So the changes allow users to set priority on Consumer and Jobs.