### PR TITLE
Update the custom class code in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ class RabbitMQJob extends BaseJob
         $method = 'handle';
 
         ($this->instance = $this->resolve($class))->{$method}($this, $payload);
+
+        $this->delete();
     }
 }
 


### PR DESCRIPTION
I have created a project with custom class described in the `README` file.
There was a problem:
The jobs queued and executed successfully, but the worker did not remove them from queue.
So every time by resetting the queue, all previous jobs executed again.
I solved this problem by adding `$this->delete()` to the custom class.