### PR TITLE
Randomize consumer tag

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -54,6 +54,12 @@ class ConsumeCommand extends WorkCommand
             return $consumerTag;
         }
 
-        return Str::slug(config('app.name', 'laravel'), '_').'_'.getmypid();
+        $consumerTag = implode('_', [
+            Str::slug(config('app.name', 'laravel')),
+            Str::slug($this->option('name')),
+            md5(serialize($this->options()).Str::random(16).getmypid()),
+        ]);
+
+        return Str::substr($consumerTag, 0, 255);
     }
 }


### PR DESCRIPTION
In a distributed environment (in my case AWS ECS with queue workers running as scalable tasks), consumer tag names can be duplicated when the workers happen to spawn with the same PID.

![duplicate_consumer_tags](https://user-images.githubusercontent.com/67554/126983005-985b4237-7c8b-4dee-9828-dc8e348feda2.png)

I'd like to propose a new generation of the consumer tag that takes into consideration

* The app name (as before)
* The name of the consumer (new, to represent the consumer name in the tag)
* A hash based on all given consumer options (new, to increase the chance of uniqueness between different consumers of the same application)
* A random string (new, to increase the chance of uniqueness even more)
* The current PID (as before)
* Limit the string to 255 chars in case the combination of app name + consumer name + md5 hash gets too long (I haven't found an official source on how long a consumer tag can be, but according to https://github.com/streadway/amqp/pull/322 it seems to be 255 chars)

:octocat: 