### PR TITLE
Add option to enable GZIP'ing messages

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -550,6 +550,12 @@ class RabbitMQQueue extends Queue implements QueueContract
             $properties['priority'] = $attempts;
         }
 
+        $encoding = $this->options['content_encoding'] ?? '';
+        if ($encoding === 'gzip') {
+            $properties['content_encoding'] = 'gzip';
+            $payload = gzdeflate($payload);
+        }
+
         if (isset($currentPayload['data']['command'])) {
             $commandData = unserialize($currentPayload['data']['command']);
             if (property_exists($commandData, 'priority')) {

--- a/tests/Feature/GzippingQueueTest.php
+++ b/tests/Feature/GzippingQueueTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Feature;
+
+use Illuminate\Support\Facades\Queue;
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestJob;
+
+/**
+ * @group functional
+ */
+class GzippingQueueTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('queue.connections.rabbitmq.options.queue', ['content_encoding' => 'gzip']);
+    }
+
+    public function testCompression(): void
+    {
+        Queue::push(new TestJob());
+
+        sleep(1);
+
+        $this->assertSame(1, Queue::size());
+        $this->assertNotNull($job = Queue::pop());
+        $this->assertSame($job->getRawBody(), gzinflate($job->getRabbitMQMessage()->getBody()));
+    }
+}


### PR DESCRIPTION
Hi, we've got a queue worker that generates fairly large messages that contain a batch of documents to be indexed in elasticsearch.

The size of the messages makes rabbitmq really unstable when we start using this due to the high memory usage this causes.

While it seems like we'll be able to move along with this by using the `worker` and `job` config options, this seemed like it could be valuable enough to have in this library itself.

Let me know if this goes in the right direction / if there are things you'd like to be updated etc...