### PR TITLE
Dispatch a job after DB transaction commit 

### DIFF
--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -44,6 +44,7 @@ class RabbitMQConnector implements ConnectorInterface
             Arr::get($config, 'worker', 'default'),
             $connection,
             $config['queue'],
+            $config['after_commit'] ?? null,
             Arr::get($config, 'options.queue', [])
         );
 
@@ -88,14 +89,20 @@ class RabbitMQConnector implements ConnectorInterface
      * @param  string  $worker
      * @param  AbstractConnection  $connection
      * @param  string  $queue
+     * @param  bool  $dispatchAfterCommit
      * @param  array  $options
      * @return HorizonRabbitMQQueue|RabbitMQQueue|Queue
      */
-    protected function createQueue(string $worker, AbstractConnection $connection, string $queue, array $options = [])
-    {
+    protected function createQueue(
+        string $worker,
+        AbstractConnection $connection,
+        string $queue,
+        $dispatchAfterCommit,
+        array $options = []
+    ) {
         switch ($worker) {
             case 'default':
-                return new RabbitMQQueue($connection, $queue, $options);
+                return new RabbitMQQueue($connection, $queue, $dispatchAfterCommit, $options);
             case 'horizon':
                 return new HorizonRabbitMQQueue($connection, $queue, $options);
             default:

--- a/tests/Mocks/TestJob.php
+++ b/tests/Mocks/TestJob.php
@@ -2,10 +2,14 @@
 
 namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
 
 class TestJob implements ShouldQueue
 {
+    use Dispatchable, Queueable;
+
     public $i;
 
     public function __construct($i = 0)


### PR DESCRIPTION
Support Laravel 8 and later

- The specific job should be dispatched after all open database transactions have been committed
 - [https://laravel.com/docs/8.x/queues\#specifying-commit-dispatch-behavior-inline](https://laravel.com/docs/8.x/queues/#specifying-commit-dispatch-behavior-inline)

Example:
Using when you want to dispatch
`TestJob::dispatch()->afterCommit();`

or you can use it on your job
```
class TestQueue implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public function __construct()
    {
        $this->onConnection('rabbitmq');
        $this->onQueue('test');
        $this->afterCommit();
    }

    public function handle()
    {
        //...
    }
}
```

also it simply use on event listener queueable
```
class TestListener implements ShouldQueue
{
    use InteractsWithQueue;

    public $afterCommit = true;

    public function viaConnection()
    {
        return 'rabbitmq';
    }

    public function handle($event)
    {
        //...
    }
}
```