### PR TITLE
Show worker name in connections RabbitMQ admin management

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -79,6 +79,9 @@ class Consumer extends Worker
 
         [$startTime, $jobsProcessed] = [hrtime(true) / 1e9, 0];
 
+        $phpAmqpLibConnection = $this->container['config']["queue.connections.$connectionName.connection"];
+        $phpAmqpLibConnection::$LIBRARY_PROPERTIES['connection_name'] = ['S', $options->name];
+
         /** @var RabbitMQQueue $connection */
         $connection = $this->manager->connection($connectionName);
 


### PR DESCRIPTION
In console command exist options worker name. I suggest using this name in connections RabbitMQ admin management.
```sh
./artisan rabbitmq:consume --name="Consumer RaSmartId"
```

Now it looks like this:

![Look bad](https://user-images.githubusercontent.com/1553797/196167651-aa9771d8-dda7-4480-b3db-0d94e83119c3.png "Look bad")

After change:

![Look good](https://user-images.githubusercontent.com/1553797/196169138-1637c7e8-9ba1-4594-851f-fa6ccdb34ae9.png "Look good")


https://github.com/php-amqplib/php-amqplib/issues/728

