### PR TITLE
pass dispatchAfterCommit into custom worker constructor

### DIFF
--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -106,7 +106,7 @@ class RabbitMQConnector implements ConnectorInterface
             case 'horizon':
                 return new HorizonRabbitMQQueue($connection, $queue, $dispatchAfterCommit, $options);
             default:
-                return new $worker($connection, $queue, $options);
+                return new $worker($connection, $queue, $dispatchAfterCommit, $options);
         }
     }
 


### PR DESCRIPTION
align constructors for custom workers and RabbitMQQueue

so there no need to map somehow constructor in case of custom worker 

```
'worker' => env('RABBITMQ_WORKER', App\Services\CustomRabbitMQQueue::class),

...

use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;

class CustomRabbitMQQueue extends RabbitMQQueue
{
```