### PR TITLE
pass dispatchAfterCommit into custom worker constructor wihtout breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,62 @@ class RabbitMQJob extends BaseJob
 }
 ```
 
+### Use your own RabbitMQQueue class
+
+To use own RabbitMQQueue set `RABBITMQ_WORKER` (or `worker` param) to your queue class.
+
+```php
+RABBITMQ_WORKER='App\\Services\\CustomRabbitMQQueue'
+```
+or
+
+```php
+    'worker' => env('RABBITMQ_WORKER', App\Services\CustomRabbitMQQueue::class),
+```
+
+where queue class is defined like
+```php
+<?php
+
+namespace App\Queue\Jobs;
+
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class CustomRabbitMQQueue extends RabbitMQQueue
+{
+    public function __construct(
+        AbstractConnection $connection,
+        string $default,
+        array $options = []
+    ) {
+```
+
+for compatibility queue constructor doesn't receive `$dispatchAfterCommit`, to use parent contructor use extra parameter in config
+```php
+    'worker' => env('RABBITMQ_WORKER', App\Services\CustomRabbitMQQueue::class),
+    'custom_worker_type' =>  'with_dispatch_after_commit',
+```
+
+then you can reuse parent constructor
+```php
+<?php
+
+namespace App\Queue\Jobs;
+
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+
+class CustomRabbitMQQueue extends RabbitMQQueue
+{
+    public function __construct(
+        AbstractConnection $connection,
+        string $default,
+        bool $dispatchAfterCommit = false,
+        array $options = []
+    ) {
+```
+
+or skip constructor entirely
+
 ## Laravel Usage
 
 Once you completed the configuration you can use the Laravel Queue API. If you used other queue drivers you do not need to

--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -42,6 +42,7 @@ class RabbitMQConnector implements ConnectorInterface
 
         $queue = $this->createQueue(
             Arr::get($config, 'worker', 'default'),
+            Arr::get($config, 'custom_worker_type', 'default'),
             $connection,
             $config['queue'],
             Arr::get($config, 'after_commit', false),
@@ -95,6 +96,7 @@ class RabbitMQConnector implements ConnectorInterface
      */
     protected function createQueue(
         string $worker,
+        string $customWorkerType,
         AbstractConnection $connection,
         string $queue,
         bool $dispatchAfterCommit,
@@ -106,7 +108,12 @@ class RabbitMQConnector implements ConnectorInterface
             case 'horizon':
                 return new HorizonRabbitMQQueue($connection, $queue, $dispatchAfterCommit, $options);
             default:
-                return new $worker($connection, $queue, $options);
+                switch ($customWorkerType) {
+                    case 'with_dispatch_after_commit':
+                        return new $worker($connection, $queue, $dispatchAfterCommit, $options);
+                    default:
+                        return new $worker($connection, $queue, $options);
+                }
         }
     }
 


### PR DESCRIPTION
- align constructors for custom workers and RabbitMQQueue
- add extra option 'custom_worker_type' =>  'with_dispatch_after_commit', to allow change type of constructor (not required, default - old behavior)

this is version of https://github.com/vyuldashev/laravel-queue-rabbitmq/pull/513 without breaking changes (things handled via extra option)

@khepin please check

