### PR TITLE
Honor the 'rest' option

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -125,6 +125,10 @@ class Consumer extends Worker
                 if ($this->supportsAsyncSignals()) {
                     $this->resetTimeoutHandler();
                 }
+
+                if ($options->rest > 0) {
+                    sleep($options->rest);
+                }
             },
             null,
             $arguments

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -127,7 +127,7 @@ class Consumer extends Worker
                 }
 
                 if ($options->rest > 0) {
-                    sleep($options->rest);
+                    $this->sleep($options->rest);
                 }
             },
             null,


### PR DESCRIPTION
From https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/529

Looks like we correctly honor all of the other `queue:work` options and have kept maintaining compatibility with `queue:work`.
There are also other options from `queue:work` that we honor despite the fact that they make little sense with this consumer. For example `sleep` when the queue is empty is useful for queues where you pull the work from the queue. Especially ones like SQS where you get charged every time you make a request. But when doing `basic_consume` this makes little sense yet it is respected by this package.

Our other choices with this `--rest` options would be:
1. accept it but ignore it (current situation). Making it the first of the `queue:work` options we are not compatible with
2. remove it (would break compatibility with `queue:work` by throwing an exception for providing an undefined option)
3. accept it and output a warning