### PR TITLE
[13.2] Add job example for handling non-json messages from rabbitmq queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,32 @@ class RabbitMQJob extends BaseJob
 }
 ```
 
+If you want to handle raw message, not in JSON format or without 'job' key in JSON, you should add stub for `getName` method:
+```php
+<?php
+
+namespace App\Queue\Jobs;
+
+use Illuminate\Support\Facades\Log;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Jobs\RabbitMQJob as BaseJob;
+
+class RabbitMQJob extends BaseJob
+{
+    public function fire()
+    {
+        $anyMessage = $this->getRawBody();
+        Log::info($anyMessage);
+
+        $this->delete();
+    }
+
+    public function getName()
+    {
+        return '';
+    }
+}
+```
+
 ## Laravel Usage
 
 Once you completed the configuration you can use the Laravel Queue API. If you used other queue drivers you do not need to


### PR DESCRIPTION
I was having troubles trying to consume raw message like `Hello`. After long research I found closed issue #437. The error was the same and [comment](https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/437#issuecomment-1228055468) helped me to fix problem. I think i'ts quite common case, to handle raw message, non JSON or without special Laravel fields. Therefore adding this to README might save developers time.