### PR TITLE
[13.3] Respect `after_commit` option for custom worker

### DIFF
--- a/src/Queue/Connectors/RabbitMQConnector.php
+++ b/src/Queue/Connectors/RabbitMQConnector.php
@@ -97,7 +97,7 @@ class RabbitMQConnector implements ConnectorInterface
             case 'horizon':
                 return new HorizonRabbitMQQueue($connection, $queue, $dispatchAfterCommit, $options);
             default:
-                return new $worker($connection, $queue, $options);
+                return new $worker($connection, $queue, $dispatchAfterCommit, $options);
         }
     }
 


### PR DESCRIPTION
See also #484

**Breaking changes**
This changes will be 100% backwards incompatible with current custom Queue Worker's.
But new method signature must be implemented btw.

**Why**
My custom queue worker extends `RabbitMQQueue`.
When i've tried to update this library from 12.0 to 13.2, i have got this error:
```
  VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue::__construct(): Argument #3 ($dispatchAfterCommit) must be of type bool, array given, called in /var/www/telemetron/vendor/vladimir-yuldashev/laravel-queue-rabbitmq/src/Queue/Connectors/RabbitMQConnector.php on line 100

  at vendor/vladimir-yuldashev/laravel-queue-rabbitmq/src/Queue/RabbitMQQueue.php:85
     81▕
     82▕     /**
     83▕      * RabbitMQQueue constructor.
     84▕      */
     85▕     public function __construct(
     86▕         AbstractConnection $connection,
     87▕         string $default,
     88▕         bool $dispatchAfterCommit = false,
     89▕         array $options = []
```


