### PR TITLE
Don't throw an error if default connection is specified in config

### DIFF
--- a/src/Queue/Connection/ConnectionFactory.php
+++ b/src/Queue/Connection/ConnectionFactory.php
@@ -202,7 +202,7 @@ class ConnectionFactory
 
     protected static function assertExtendedOf($connection, string $abstract): void
     {
-        if (! is_subclass_of($connection, $abstract)) {
+        if ($connection !== $abstract && ! is_subclass_of($connection, $abstract)) {
             throw new AMQPLogicException(sprintf('The connection must extend: %s', class_basename($abstract)));
         }
     }


### PR DESCRIPTION
I updated to a newest version of package and started getting an error:
```
The connection must extend: AMQPStreamConnection (at vendor/vladimir-yuldashev/laravel-queue-rabbitmq/src/Queue/Connection/ConnectionFactory.php:206)
```

I checked connection which I use and it turned out that my connection in `queue.php` was `AMQPStreamConnection`, which is default connection. And everything works fine if I remove a line from config, in which connection is declared.

But I think this behavior is not fully right and we should check not only the fact that connection from config is subclass of an abstract connection (which is default connection), but also check that connection is also not an instance of this abstraction.