### PR TITLE
Fix for errors on $currentJob property

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -54,7 +54,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     /**
      * Current job being processed.
      */
-    protected RabbitMQJob $currentJob;
+    protected ?RabbitMQJob $currentJob = null;
 
     /**
      * Holds the Configuration


### PR DESCRIPTION
RabbitMQQueue::$currentJob must not be accessed before initialization

Fixes for issue: #572 #555