### PR TITLE
Allow for encrypted command data

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <env name="PORT" value="5672"/>
     <env name="PORT_SSL" value="5671"/>
     <env name="RABBITMQ_SSL_CAFILE" value="./tests/files/rootCA.pem"/>
+    <env name="APP_KEY" value="12345678901234567890123456789012"/>
   </php>
   <logging/>
 </phpunit>

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -7,8 +7,10 @@ namespace VladimirYuldashev\LaravelQueueRabbitMQ\Queue;
 use ErrorException;
 use Exception;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
@@ -526,10 +528,10 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
         if (isset($currentPayload['data']['command'])) {
             // If the command data is encrypted, decrypt it first before attempting to unserialize
-            if (in_array(ShouldBeEncrypted::class, class_implements($currentPayload['data']['commandName']))) {
-                $currentPayload['data']['command'] = decrypt($currentPayload['data']['command']);
+            if (is_subclass_of($currentPayload['data']['commandName'], ShouldBeEncrypted::class)) {
+                $currentPayload['data']['command'] = Crypt::decrypt($currentPayload['data']['command']);
             }
-            
+
             $commandData = unserialize($currentPayload['data']['command']);
             if (property_exists($commandData, 'priority')) {
                 $properties['priority'] = $commandData->priority;

--- a/tests/Mocks/TestEncryptedJob.php
+++ b/tests/Mocks/TestEncryptedJob.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class TestEncryptedJob implements ShouldBeEncrypted, ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public $i;
+
+    public function __construct($i = 0)
+    {
+        $this->i = $i;
+    }
+
+    public function handle(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
If a Laravel Job implements `ShouldBeEncrypted`, when dispatching it to RabbitMQ via this package throws the following error:

`NOTICE  unserialize(): Error at offset 0 of 17380 bytes in vendor/vladimir-yuldashev/laravel-queue-rabbitmq/src/Queue/RabbitMQQueue.php on line 528.`

Added a bugfix to handle fetching priority from encrypted command data if the job class implements `ShouldBeEncrypted`