### PR TITLE
Document the exceptions thrown by publishBasic()

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Exception\AMQPChannelClosedException;
+use PhpAmqpLib\Exception\AMQPConnectionBlockedException;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
@@ -739,6 +740,11 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         return $this->config;
     }
 
+    /**
+     * @throws AMQPChannelClosedException
+     * @throws AMQPConnectionClosedException
+     * @throws AMQPConnectionBlockedException
+     */
     protected function publishBasic($msg, $exchange = '', $destination = '', $mandatory = false, $immediate = false, $ticket = null): void
     {
         $this->getChannel()->basic_publish($msg, $exchange, $destination, $mandatory, $immediate, $ticket);


### PR DESCRIPTION
Hi,

I work on a project where we override `publishBasic()` like this:
```php
try {
    parent::publishBasic($msg, $exchange, $destination, $mandatory, $immediate, $ticket);
} catch (AMQPConnectionClosedException|AMQPChannelClosedException) {
    $this->reconnect();
    parent::publishBasic($msg, $exchange, $destination, $mandatory, $immediate, $ticket);
}
```

but PHPStan emits this error:
```
Dead catch - PhpAmqpLib\Exception\AMQPChannelClosedException\|PhpAmqpLib\Exception\AMQPConnectionClosedException is never thrown in the try block.
```

These changes will fix this issue.