### PR TITLE
Added requeue parameter for markAsFailed()

### DIFF
--- a/src/Queue/Jobs/RabbitMQJob.php
+++ b/src/Queue/Jobs/RabbitMQJob.php
@@ -84,14 +84,14 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * {@inheritdoc}
      */
-    public function markAsFailed(): void
+    public function markAsFailed(bool $requeue = false): void
     {
         parent::markAsFailed();
 
-        // We must tel rabbitMQ this Job is failed
+        // We must tell rabbitMQ this Job is failed
         // The message must be rejected when the Job marked as failed, in case rabbitMQ wants to do some extra magic.
-        // like: Death lettering the message to an other exchange/routing-key.
-        $this->rabbitmq->reject($this);
+        // like: Death lettering the message to another exchange/routing-key.
+        $this->rabbitmq->reject($this, $requeue);
     }
 
     /**


### PR DESCRIPTION
`reject(RabbitMQJob $job, bool $requeue = false)` supports second parameter $requeue. I suggest adding a second parameter to make the method `markAsFailed()` more flexible.