### PR TITLE
Added config option to allow disabling `x-expires` in `getDelayQueueArguments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,30 @@ by adding extra options.
 ],
 ```
 
+When you want to disable x-expires from a delayed queue, then this is possible by adding extra option on queue `expire_delay_queue`.
+- When the `expire_delay_queue` option is omitted, it is considered to be true.
+- Useful for when you're using quorum queues, as they risk to delete the queue before the messages are moved to their destination queue.
+
+```php
+'connections' => [
+    // ...
+
+    'rabbitmq' => [
+        // ...
+
+        'options' => [
+            'queue' => [
+                // ...
+
+                'expire_delay_queue' => false,
+            ],
+        ],
+    ],
+
+    // ...    
+],
+```
+
 ### Horizon support
 
 Starting with 8.0, this package supports [Laravel Horizon](https://laravel.com/docs/horizon) out of the box. Firstly,

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^10.0|^11.0",
+        "illuminate/queue": "^10.0|^11.0|^12.0",
         "php-amqplib/php-amqplib": "^v3.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0",
         "mockery/mockery": "^1.0",
         "laravel/horizon": "^5.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "laravel/pint": "^1.2",
-        "laravel/framework": "^9.0|^10.0|^11.0"
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -30,6 +30,8 @@ class QueueConfig
 
     protected bool $quorum = false;
 
+    protected bool $expireDelayQueue = true;
+
     protected array $options = [];
 
     /**
@@ -258,6 +260,21 @@ class QueueConfig
     public function setOptions(array $options): QueueConfig
     {
         $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Returns &true;, if the delay queue should expire.
+     */
+    public function hasExpireDelayQueue(): bool
+    {
+        return $this->expireDelayQueue;
+    }
+
+    public function setExpireDelayQueue($expireDelayQueue): QueueConfig
+    {
+        $this->expireDelayQueue = $this->toBoolean($expireDelayQueue);
 
         return $this;
     }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -68,6 +68,11 @@ class QueueConfigFactory
             $queueConfig->setQuorum($quorum);
         }
 
+        // Feature: Enable/disable x-expires from delay queue.
+        if (! is_null($expireDelayQueue = Arr::pull($queueOptions, 'expire_delay_queue'))) {
+            $queueConfig->setExpireDelayQueue($expireDelayQueue);
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -626,12 +626,17 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getDelayQueueArguments(string $destination, int $ttl): array
     {
-        return [
+        $arguments = [
             'x-dead-letter-exchange' => $this->getExchange(),
             'x-dead-letter-routing-key' => $this->getRoutingKey($destination),
             'x-message-ttl' => $ttl,
-            'x-expires' => $ttl * 2,
         ];
+
+        if ($this->getConfig()->hasExpireDelayQueue()) {
+            $arguments['x-expires'] = $ttl * 2;
+        }
+
+        return $arguments;
     }
 
     /**


### PR DESCRIPTION
I am using quorum and i noticed that the messages are deleted before they're moved to their destination queue.
By disabling the `x-expires`, my messages are no longer lost.

I think is considerate to have the ability to enable/disable delay queue expires, not necessarily for users that use quorum.

Found other issue related -> https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/601