### PR TITLE
fix: Add method readyNow() to support Horizon

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -74,6 +74,17 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     }
 
     /**
+     * Get the number of queue jobs that are ready to process.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function readyNow($queue = null): int
+    {
+        return $this->size($queue);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @throws AMQPProtocolChannelException


### PR DESCRIPTION
From this [issue](https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/439)

I just add require method that using with Laravel Horizon to get the number of queue