### PR TITLE
Fix formatting and clean up deprecated docker-compose v1 from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,15 +33,8 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip
           coverage: none
 
-      - name: Set up Docker
-        run: |
-          sudo rm /usr/local/bin/docker-compose
-          curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-
       - name: Start Docker container
-        run: docker-compose up -d rabbitmq
+        run: docker compose up -d rabbitmq
 
       - name: Install dependencies
         run: composer update --with='laravel/framework:${{matrix.laravel}}' --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -16,7 +16,7 @@ class ConfigFactory
      */
     public static function make(array $config = []): AMQPConnectionConfig
     {
-        return tap(new AMQPConnectionConfig(), function (AMQPConnectionConfig $connectionConfig) use ($config) {
+        return tap(new AMQPConnectionConfig, function (AMQPConnectionConfig $connectionConfig) use ($config) {
             // Set the connection to a Lazy by default
             $connectionConfig->setIsLazy(! in_array(
                 Arr::get($config, 'lazy') ?? true,

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -13,7 +13,7 @@ class QueueConfigFactory
      */
     public static function make(array $config = []): QueueConfig
     {
-        return tap(new QueueConfig(), function (QueueConfig $queueConfig) use ($config) {
+        return tap(new QueueConfig, function (QueueConfig $queueConfig) use ($config) {
             if (! empty($queue = Arr::get($config, 'queue'))) {
                 $queueConfig->setQueue($queue);
             }

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -12,7 +12,7 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestSSLConnection;
 
 class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase
 {
-    public function testLazyConnection(): void
+    public function test_lazy_connection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',
@@ -55,7 +55,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
         $this->assertTrue($connection->getConnection()->isConnected());
     }
 
-    public function testLazyStreamConnection(): void
+    public function test_lazy_stream_connection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',
@@ -98,7 +98,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
         $this->assertTrue($connection->getConnection()->isConnected());
     }
 
-    public function testSslConnection(): void
+    public function test_ssl_connection(): void
     {
         $this->markTestSkipped();
 
@@ -142,7 +142,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
     }
 
     // Test to validate ssl connection params
-    public function testNoVerificationSslConnection(): void
+    public function test_no_verification_ssl_connection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',

--- a/tests/Feature/QueueTest.php
+++ b/tests/Feature/QueueTest.php
@@ -10,7 +10,7 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestJob;
 
 class QueueTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -20,16 +20,16 @@ class QueueTest extends TestCase
         ]);
     }
 
-    public function testConnection(): void
+    public function test_connection(): void
     {
         $this->assertInstanceOf(AMQPStreamConnection::class, $this->connection()->getChannel()->getConnection());
     }
 
-    public function testWithoutReconnect(): void
+    public function test_without_reconnect(): void
     {
         $queue = $this->connection('rabbitmq');
 
-        $queue->push(new TestJob());
+        $queue->push(new TestJob);
         sleep(1);
         $this->assertSame(1, $queue->size());
 
@@ -38,6 +38,6 @@ class QueueTest extends TestCase
         $this->assertFalse($queue->getConnection()->isConnected());
 
         $this->expectException(AMQPChannelClosedException::class);
-        $queue->push(new TestJob());
+        $queue->push(new TestJob);
     }
 }

--- a/tests/Feature/SslQueueTest.php
+++ b/tests/Feature/SslQueueTest.php
@@ -6,7 +6,7 @@ use PhpAmqpLib\Connection\AMQPSSLConnection;
 
 class SslQueueTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->markTestSkipped();
     }
@@ -43,7 +43,7 @@ class SslQueueTest extends TestCase
         ]);
     }
 
-    public function testConnection(): void
+    public function test_connection(): void
     {
         $this->assertInstanceOf(AMQPSSLConnection::class, $this->connection()->getChannel()->getConnection());
     }

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -17,7 +17,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * @throws AMQPProtocolChannelException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -40,17 +40,17 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
     }
 
-    public function testSizeDoesNotThrowExceptionOnUnknownQueue(): void
+    public function test_size_does_not_throw_exception_on_unknown_queue(): void
     {
         $this->assertEmpty(0, Queue::size(Str::random()));
     }
 
-    public function testPopNothing(): void
+    public function test_pop_nothing(): void
     {
         $this->assertNull(Queue::pop('foo'));
     }
 
-    public function testPushRaw(): void
+    public function test_push_raw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -68,9 +68,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testPush(): void
+    public function test_push(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         sleep(1);
 
@@ -95,7 +95,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testPushAfterCommit(): void
+    public function test_push_after_commit(): void
     {
         $transaction = new DatabaseTransactionsManager;
 
@@ -122,7 +122,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testLaterRaw(): void
+    public function test_later_raw(): void
     {
         $payload = Str::random();
         $data = [Str::random() => Str::random()];
@@ -152,9 +152,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testLater(): void
+    public function test_later(): void
     {
-        Queue::later(3, new TestJob());
+        Queue::later(3, new TestJob);
 
         sleep(1);
 
@@ -179,7 +179,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testBulk(): void
+    public function test_bulk(): void
     {
         $count = 100;
         $jobs = [];
@@ -195,9 +195,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame($count, Queue::size());
     }
 
-    public function testPushEncrypted(): void
+    public function test_push_encrypted(): void
     {
-        Queue::push(new TestEncryptedJob());
+        Queue::push(new TestEncryptedJob);
 
         sleep(1);
 
@@ -222,7 +222,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testPushEncryptedAfterCommit(): void
+    public function test_push_encrypted_after_commit(): void
     {
         $transaction = new DatabaseTransactionsManager;
 
@@ -249,9 +249,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testEncryptedLater(): void
+    public function test_encrypted_later(): void
     {
-        Queue::later(3, new TestEncryptedJob());
+        Queue::later(3, new TestEncryptedJob);
 
         sleep(1);
 
@@ -276,7 +276,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testEncryptedBulk(): void
+    public function test_encrypted_bulk(): void
     {
         $count = 100;
         $jobs = [];
@@ -292,7 +292,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame($count, Queue::size());
     }
 
-    public function testReleaseRaw(): void
+    public function test_release_raw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -318,9 +318,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testRelease(): void
+    public function test_release(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         sleep(1);
 
@@ -344,7 +344,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testReleaseWithDelayRaw(): void
+    public function test_release_with_delay_raw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -375,9 +375,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testReleaseInThePast(): void
+    public function test_release_in_the_past(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         $job = Queue::pop();
         $job->release(-3);
@@ -390,9 +390,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testReleaseAndReleaseWithDelayAttempts(): void
+    public function test_release_and_release_with_delay_attempts(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         sleep(1);
 
@@ -417,9 +417,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function testDelete(): void
+    public function test_delete(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         $job = Queue::pop();
 
@@ -431,9 +431,9 @@ abstract class TestCase extends BaseTestCase
         $this->assertNull(Queue::pop());
     }
 
-    public function testFailed(): void
+    public function test_failed(): void
     {
-        Queue::push(new TestJob());
+        Queue::push(new TestJob);
 
         $job = Queue::pop();
 

--- a/tests/Functional/RabbitMQQueueTest.php
+++ b/tests/Functional/RabbitMQQueueTest.php
@@ -9,7 +9,7 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Functional\TestCase as BaseTest
 
 class RabbitMQQueueTest extends BaseTestCase
 {
-    public function testConnection(): void
+    public function test_connection(): void
     {
         $queue = $this->connection();
         $this->assertInstanceOf(RabbitMQQueue::class, $queue);
@@ -21,7 +21,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertInstanceOf(RabbitMQQueue::class, $queue);
     }
 
-    public function testConfigRerouteFailed(): void
+    public function test_config_reroute_failed(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isRerouteFailed());
@@ -36,7 +36,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($this->callProperty($queue, 'config')->isRerouteFailed());
     }
 
-    public function testConfigPrioritizeDelayed(): void
+    public function test_config_prioritize_delayed(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isPrioritizeDelayed());
@@ -51,7 +51,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($this->callProperty($queue, 'config')->isPrioritizeDelayed());
     }
 
-    public function testQueueMaxPriority(): void
+    public function test_queue_max_priority(): void
     {
         $queue = $this->connection();
         $this->assertIsInt($this->callProperty($queue, 'config')->getQueueMaxPriority());
@@ -70,7 +70,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame(2, $this->callProperty($queue, 'config')->getQueueMaxPriority());
     }
 
-    public function testConfigExchangeType(): void
+    public function test_config_exchange_type(): void
     {
         $queue = $this->connection();
         $this->assertSame(AMQPExchangeType::DIRECT, $this->callMethod($queue, 'getExchangeType'));
@@ -87,12 +87,12 @@ class RabbitMQQueueTest extends BaseTestCase
         $queue = $this->connection('rabbitmq-with-options-null');
         $this->assertSame(AMQPExchangeType::DIRECT, $this->callMethod($queue, 'getExchangeType'));
 
-        //testing an unkown type with a default
+        // testing an unkown type with a default
         $this->callProperty($queue, 'config')->setExchangeType('unknown');
         $this->assertSame(AMQPExchangeType::DIRECT, $this->callMethod($queue, 'getExchangeType'));
     }
 
-    public function testExchange(): void
+    public function test_exchange(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getExchange', ['test']));
@@ -119,7 +119,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('', $this->callMethod($queue, 'getExchange', ['']));
     }
 
-    public function testFailedExchange(): void
+    public function test_failed_exchange(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getFailedExchange', ['test']));
@@ -146,7 +146,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('', $this->callMethod($queue, 'getFailedExchange', ['']));
     }
 
-    public function testRoutingKey(): void
+    public function test_routing_key(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getRoutingKey', ['test']));
@@ -165,7 +165,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('an.alternate.routing-key', $this->callMethod($queue, 'getRoutingKey', ['test']));
     }
 
-    public function testFailedRoutingKey(): void
+    public function test_failed_routing_key(): void
     {
         $queue = $this->connection();
         $this->assertSame('test.failed', $this->callMethod($queue, 'getFailedRoutingKey', ['test']));
@@ -184,7 +184,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('an.alternate.routing-key', $this->callMethod($queue, 'getFailedRoutingKey', ['test']));
     }
 
-    public function testConfigQuorum(): void
+    public function test_config_quorum(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isQuorum());
@@ -202,7 +202,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertTrue($this->callProperty($queue, 'config')->isQuorum());
     }
 
-    public function testDeclareDeleteExchange(): void
+    public function test_declare_delete_exchange(): void
     {
         $queue = $this->connection();
 
@@ -217,7 +217,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($queue->isExchangeExists($name));
     }
 
-    public function testDeclareDeleteQueue(): void
+    public function test_declare_delete_queue(): void
     {
         $queue = $this->connection();
 
@@ -232,7 +232,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($queue->isQueueExists($name));
     }
 
-    public function testQueueArguments(): void
+    public function test_queue_arguments(): void
     {
         $name = Str::random();
 
@@ -272,7 +272,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertEquals(array_values($expected), array_values($actual));
     }
 
-    public function testDelayQueueArguments(): void
+    public function test_delay_queue_arguments(): void
     {
         $name = Str::random();
         $ttl = 12000;

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -236,7 +236,7 @@ abstract class TestCase extends BaseTestCase
         return $property->getValue($object);
     }
 
-    public function testConnectChannel(): void
+    public function test_connect_channel(): void
     {
         $queue = $this->connection();
         $this->assertFalse($queue->getConnection()->isConnected());
@@ -248,7 +248,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertTrue($channel->is_open());
     }
 
-    public function testReconnect(): void
+    public function test_reconnect(): void
     {
         $queue = $this->connection();
         $this->assertFalse($queue->getConnection()->isConnected());


### PR DESCRIPTION
This PR applies code style corrections and removes the deprecated manual installation of Docker Compose v1, which was officially removed from GitHub-hosted runners on April 10, 2024 ([source](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/?utm_source=chatgpt.com)).

- Reformatted files to comply with the project's linting configuration
- Removed legacy Docker Compose v1 installation from the CI workflow
- No functional changes were made to the application code
- Ensures compatibility with the current ubuntu-latest GitHub runner image
- Helps keep CI/CD pipelines green

![image](https://github.com/user-attachments/assets/b29ae303-ab39-4fb9-8d86-e61381a057db)
GitHub Actions running on my fork — legacy docker-compose v1 removed, linting errors resolved

Let me know if any adjustments are needed.