### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,12 @@ jobs:
       matrix:
         php: ['8.1', '8.2', '8.3']
         stability: ['prefer-lowest', 'prefer-stable']
-        laravel: ['^10.0', '^11.0']
+        laravel: ['^10.0', '^11.0', '^12.0']
         exclude:
           - php: '8.1'
             laravel: '^11.0'
+          - php: '8.1'
+            laravel: '^12.0'
 
     name: 'PHP ${{ matrix.php }} - Laravel: ${{matrix.laravel}} - ${{ matrix.stability }}'
 

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^10.0|^11.0",
+        "illuminate/queue": "^10.0|^11.0|^12.0",
         "php-amqplib/php-amqplib": "^v3.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0",
         "mockery/mockery": "^1.0",
         "laravel/horizon": "^5.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "laravel/pint": "^1.2",
-        "laravel/framework": "^9.0|^10.0|^11.0"
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends BaseTestCase
                     'cafile' => null,
                     'local_cert' => null,
                     'local_key' => null,
-                    'verify_peer' => true,
+                    'verify_peer' => false,
                     'passphrase' => null,
                 ],
             ],


### PR DESCRIPTION
This PR continues the work started in #624 to add support for Laravel 12.

- Adds Laravel 12 to the test matrix and composer.json version constraints
- Fixes a test failure by disabling verify_peer in the SSL config during test setup, preventing dropped connections with AMQPLazyConnection

> Due to a version constraint in orchestra/testbench, which only supports laravel/framework starting from 12.0.1, it is not possible to test against the exact 12.0.0 version.

Closes #619 