### PR TITLE
Add --json support to rabbitmq:consume and align option order

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -21,9 +21,10 @@ class ConsumeCommand extends WorkCommand
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : Number of times to attempt a job before logging it failed}
-                            {--rest=0 : Number of seconds to rest between jobs}
+                            {--json : Output the queue worker information as JSON}
 
                             {--max-priority=}
                             {--consumer-tag}


### PR DESCRIPTION
Adds the `--json` flag to the rabbitmq:consume command for structured logging, matching Laravel's `queue:work`.

Also reorders the command options to follow the same structure as Laravel’s WorkCommand, for consistency.

This change does not break compatibility with Laravel 10, which is still supported by the package, as the `--json` flag was designed to be optional and backward-compatible.

Closes #603