### PR TITLE
Added config option to allow disabling x-expires in `getDelayQueueArguments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,30 @@ by adding extra options.
 ],
 ```
 
+When you want to disable x-expires from a delayed queue, then this is possible by adding extra option on queue `expire_delay_queue`.
+- When the `expire_delay_queue` option is omitted, it is considered to be true.
+- Useful for when you're using quorum queues, as they risk to delete the queue before the messages are moved to their destination queue.
+
+```php
+'connections' => [
+    // ...
+
+    'rabbitmq' => [
+        // ...
+
+        'options' => [
+            'queue' => [
+                // ...
+
+                'expire_delay_queue' => false,
+            ],
+        ],
+    ],
+
+    // ...    
+],
+```
+
 ### Horizon support
 
 Starting with 8.0, this package supports [Laravel Horizon](https://laravel.com/docs/horizon) out of the box. Firstly,

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -30,6 +30,8 @@ class QueueConfig
 
     protected bool $quorum = false;
 
+    protected bool $expireDelayQueue = true;
+
     protected array $options = [];
 
     /**
@@ -258,6 +260,21 @@ class QueueConfig
     public function setOptions(array $options): QueueConfig
     {
         $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Returns &true;, if the delay queue should expire.
+     */
+    public function hasExpireDelayQueue(): bool
+    {
+        return $this->expireDelayQueue;
+    }
+
+    public function setExpireDelayQueue($expireDelayQueue): QueueConfig
+    {
+        $this->expireDelayQueue = $this->toBoolean($expireDelayQueue);
 
         return $this;
     }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -68,6 +68,11 @@ class QueueConfigFactory
             $queueConfig->setQuorum($quorum);
         }
 
+        // Feature: Enable/disable x-expires from delay queue.
+        if (! is_null($expireDelayQueue = Arr::pull($queueOptions, 'expire_delay_queue'))) {
+            $queueConfig->setExpireDelayQueue($expireDelayQueue);
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -658,12 +658,17 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getDelayQueueArguments(string $destination, int $ttl): array
     {
-        return [
+        $arguments = [
             'x-dead-letter-exchange' => $this->getExchange(),
             'x-dead-letter-routing-key' => $this->getRoutingKey($destination),
             'x-message-ttl' => $ttl,
-            'x-expires' => $ttl * 2,
         ];
+
+        if ($this->getRabbitMQConfig()->hasExpireDelayQueue()) {
+            $arguments['x-expires'] = $ttl * 2;
+        }
+
+        return $arguments;
     }
 
     /**


### PR DESCRIPTION
I am using quorum and i noticed that the messages are deleted before they're moved to their destination queue.
By disabling the `x-expires`, my messages are no longer lost.

I think is considerate to have the ability to enable/disable delay queue expires, to avoid issues for users that use quorum.

Found other issue related -> https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/601

----

### From the TTL documentation (/ttl):
This page describes the key difference for x-expires. 

> "Queues will expire after a period of time only when they are not used (a queue is used if it has online consumers). ... This controls for how long a queue can be unused before it is automatically deleted."

### From the Quorum Queues documentation (/quorum-queues):
This page describes the core design that explains why the TTL behavior is different.

> "Quorum queues are optimized for certain use cases where data safety is the top priority."
"Quorum queues have differences in behaviour compared to classic queues as well as some limitations that it is important to be aware of..."

When combined, these two pages explain that the "unused" criteria for Classic queues (which prevents deletion if messages are present) does not apply to the more robust, data-safe Quorum queues, which prioritize consistency and guaranteed cleanup.