### PR TITLE
Add PHP 8.4 to CI and fix test method naming to follow camelCase convention

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
         stability: ['prefer-lowest', 'prefer-stable']
         laravel: ['^10.0', '^11.0', '^12.0']
         exclude:

--- a/pint.json
+++ b/pint.json
@@ -2,7 +2,7 @@
   "preset": "laravel",
   "rules": {
     "php_unit_method_casing": {
-        "case": "camel_case"
+      "case": "camel_case"
     }
   }
 }

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -12,7 +12,7 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestSSLConnection;
 
 class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase
 {
-    public function test_lazy_connection(): void
+    public function testLazyConnection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',
@@ -55,7 +55,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
         $this->assertTrue($connection->getConnection()->isConnected());
     }
 
-    public function test_lazy_stream_connection(): void
+    public function testLazyStreamConnection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',
@@ -98,7 +98,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
         $this->assertTrue($connection->getConnection()->isConnected());
     }
 
-    public function test_ssl_connection(): void
+    public function testSslConnection(): void
     {
         $this->markTestSkipped();
 
@@ -142,7 +142,7 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
     }
 
     // Test to validate ssl connection params
-    public function test_no_verification_ssl_connection(): void
+    public function testNoVerificationSslConnection(): void
     {
         $this->app['config']->set('queue.connections.rabbitmq', [
             'driver' => 'rabbitmq',

--- a/tests/Feature/QueueTest.php
+++ b/tests/Feature/QueueTest.php
@@ -20,12 +20,12 @@ class QueueTest extends TestCase
         ]);
     }
 
-    public function test_connection(): void
+    public function testConnection(): void
     {
         $this->assertInstanceOf(AMQPStreamConnection::class, $this->connection()->getChannel()->getConnection());
     }
 
-    public function test_without_reconnect(): void
+    public function testWithoutReconnect(): void
     {
         $queue = $this->connection('rabbitmq');
 

--- a/tests/Feature/SslQueueTest.php
+++ b/tests/Feature/SslQueueTest.php
@@ -43,7 +43,7 @@ class SslQueueTest extends TestCase
         ]);
     }
 
-    public function test_connection(): void
+    public function testConnection(): void
     {
         $this->assertInstanceOf(AMQPSSLConnection::class, $this->connection()->getChannel()->getConnection());
     }

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -40,17 +40,17 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
     }
 
-    public function test_size_does_not_throw_exception_on_unknown_queue(): void
+    public function testSizeDoesNotThrowExceptionOnUnknownQueue(): void
     {
         $this->assertEmpty(0, Queue::size(Str::random()));
     }
 
-    public function test_pop_nothing(): void
+    public function testPopNothing(): void
     {
         $this->assertNull(Queue::pop('foo'));
     }
 
-    public function test_push_raw(): void
+    public function testPushRaw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -68,7 +68,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_push(): void
+    public function testPush(): void
     {
         Queue::push(new TestJob);
 
@@ -95,7 +95,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_push_after_commit(): void
+    public function testPushAfterCommit(): void
     {
         $transaction = new DatabaseTransactionsManager;
 
@@ -122,7 +122,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_later_raw(): void
+    public function testLaterRaw(): void
     {
         $payload = Str::random();
         $data = [Str::random() => Str::random()];
@@ -152,7 +152,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_later(): void
+    public function testLater(): void
     {
         Queue::later(3, new TestJob);
 
@@ -179,7 +179,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_bulk(): void
+    public function testBulk(): void
     {
         $count = 100;
         $jobs = [];
@@ -195,7 +195,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame($count, Queue::size());
     }
 
-    public function test_push_encrypted(): void
+    public function testPushEncrypted(): void
     {
         Queue::push(new TestEncryptedJob);
 
@@ -222,7 +222,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_push_encrypted_after_commit(): void
+    public function testPushEncryptedAfterCommit(): void
     {
         $transaction = new DatabaseTransactionsManager;
 
@@ -249,7 +249,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_encrypted_later(): void
+    public function testEncryptedLater(): void
     {
         Queue::later(3, new TestEncryptedJob);
 
@@ -276,7 +276,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_encrypted_bulk(): void
+    public function testEncryptedBulk(): void
     {
         $count = 100;
         $jobs = [];
@@ -292,7 +292,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame($count, Queue::size());
     }
 
-    public function test_release_raw(): void
+    public function testReleaseRaw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -318,7 +318,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_release(): void
+    public function testRelease(): void
     {
         Queue::push(new TestJob);
 
@@ -344,7 +344,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_release_with_delay_raw(): void
+    public function testReleaseWithDelayRaw(): void
     {
         Queue::pushRaw($payload = Str::random());
 
@@ -375,7 +375,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_release_in_the_past(): void
+    public function testReleaseInThePast(): void
     {
         Queue::push(new TestJob);
 
@@ -390,7 +390,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_release_and_release_with_delay_attempts(): void
+    public function testReleaseAndReleaseWithDelayAttempts(): void
     {
         Queue::push(new TestJob);
 
@@ -417,7 +417,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertSame(0, Queue::size());
     }
 
-    public function test_delete(): void
+    public function testDelete(): void
     {
         Queue::push(new TestJob);
 
@@ -431,7 +431,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertNull(Queue::pop());
     }
 
-    public function test_failed(): void
+    public function testFailed(): void
     {
         Queue::push(new TestJob);
 

--- a/tests/Functional/RabbitMQQueueTest.php
+++ b/tests/Functional/RabbitMQQueueTest.php
@@ -9,7 +9,7 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Functional\TestCase as BaseTest
 
 class RabbitMQQueueTest extends BaseTestCase
 {
-    public function test_connection(): void
+    public function testConnection(): void
     {
         $queue = $this->connection();
         $this->assertInstanceOf(RabbitMQQueue::class, $queue);
@@ -21,7 +21,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertInstanceOf(RabbitMQQueue::class, $queue);
     }
 
-    public function test_config_reroute_failed(): void
+    public function testConfigRerouteFailed(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isRerouteFailed());
@@ -36,7 +36,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($this->callProperty($queue, 'config')->isRerouteFailed());
     }
 
-    public function test_config_prioritize_delayed(): void
+    public function testConfigPrioritizeDelayed(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isPrioritizeDelayed());
@@ -51,7 +51,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($this->callProperty($queue, 'config')->isPrioritizeDelayed());
     }
 
-    public function test_queue_max_priority(): void
+    public function testQueueMaxPriority(): void
     {
         $queue = $this->connection();
         $this->assertIsInt($this->callProperty($queue, 'config')->getQueueMaxPriority());
@@ -70,7 +70,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame(2, $this->callProperty($queue, 'config')->getQueueMaxPriority());
     }
 
-    public function test_config_exchange_type(): void
+    public function testConfigExchangeType(): void
     {
         $queue = $this->connection();
         $this->assertSame(AMQPExchangeType::DIRECT, $this->callMethod($queue, 'getExchangeType'));
@@ -92,7 +92,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame(AMQPExchangeType::DIRECT, $this->callMethod($queue, 'getExchangeType'));
     }
 
-    public function test_exchange(): void
+    public function testExchange(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getExchange', ['test']));
@@ -119,7 +119,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('', $this->callMethod($queue, 'getExchange', ['']));
     }
 
-    public function test_failed_exchange(): void
+    public function testFailedExchange(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getFailedExchange', ['test']));
@@ -146,7 +146,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('', $this->callMethod($queue, 'getFailedExchange', ['']));
     }
 
-    public function test_routing_key(): void
+    public function testRoutingKey(): void
     {
         $queue = $this->connection();
         $this->assertSame('test', $this->callMethod($queue, 'getRoutingKey', ['test']));
@@ -165,7 +165,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('an.alternate.routing-key', $this->callMethod($queue, 'getRoutingKey', ['test']));
     }
 
-    public function test_failed_routing_key(): void
+    public function testFailedRoutingKey(): void
     {
         $queue = $this->connection();
         $this->assertSame('test.failed', $this->callMethod($queue, 'getFailedRoutingKey', ['test']));
@@ -184,7 +184,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertSame('an.alternate.routing-key', $this->callMethod($queue, 'getFailedRoutingKey', ['test']));
     }
 
-    public function test_config_quorum(): void
+    public function testConfigQuorum(): void
     {
         $queue = $this->connection();
         $this->assertFalse($this->callProperty($queue, 'config')->isQuorum());
@@ -202,7 +202,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertTrue($this->callProperty($queue, 'config')->isQuorum());
     }
 
-    public function test_declare_delete_exchange(): void
+    public function testDeclareDeleteExchange(): void
     {
         $queue = $this->connection();
 
@@ -217,7 +217,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($queue->isExchangeExists($name));
     }
 
-    public function test_declare_delete_queue(): void
+    public function testDeclareDeleteQueue(): void
     {
         $queue = $this->connection();
 
@@ -232,7 +232,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertFalse($queue->isQueueExists($name));
     }
 
-    public function test_queue_arguments(): void
+    public function testQueueArguments(): void
     {
         $name = Str::random();
 
@@ -272,7 +272,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertEquals(array_values($expected), array_values($actual));
     }
 
-    public function test_delay_queue_arguments(): void
+    public function testDelayQueueArguments(): void
     {
         $name = Str::random();
         $ttl = 12000;

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -236,7 +236,7 @@ abstract class TestCase extends BaseTestCase
         return $property->getValue($object);
     }
 
-    public function test_connect_channel(): void
+    public function testConnectChannel(): void
     {
         $queue = $this->connection();
         $this->assertFalse($queue->getConnection()->isConnected());
@@ -248,7 +248,7 @@ abstract class TestCase extends BaseTestCase
         $this->assertTrue($channel->is_open());
     }
 
-    public function test_reconnect(): void
+    public function testReconnect(): void
     {
         $queue = $this->connection();
         $this->assertFalse($queue->getConnection()->isConnected());


### PR DESCRIPTION
This PR introduces two changes. First, it adds PHP 8.4 to the test matrix, as the version has been officially released for over five months and is currently in its active support phase. Ensuring compatibility with PHP 8.4 is important for forward-compatibility and maintaining the reliability of the package across supported environments.

The second change corrects the naming style of PHPUnit test methods. While reviewing the updates made in PR #616, "Fixed php-8.4 deprecations" by @sergonie, I realized that my earlier PR #622, "Fix formatting and clean up deprecated docker-compose v1 from CI", unintentionally changed test method names from camelCase to snake_case. 

The Pint configuration added in PR #616 explicitly defined the use of camelCase, which reflects the historical naming convention used in this package. This PR restores that convention by renaming all test methods back to camelCase for consistency.

Tests pass: https://github.com/fontebasso/laravel-queue-rabbitmq/actions/runs/14767716517