### PR TITLE
Add blocking mode with auto-reconnection and some other features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -557,6 +557,50 @@ There are two ways of consuming messages.
 
 2. `rabbitmq:consume` command which is provided by this package. This command utilizes `basic_consume` and is more performant than `basic_get` by ~2x, but does not support multiple queues.
 
+### Getting performance and durability
+To get the best performance and durability you must use option 2, and you need to extend the base config and use some extra options in the command.
+
+The command to execute:
+```bash
+  rabbitmq:consume --blocking=1 --auto-reconnect=1 --alive-check=30 --init-queue=1 --verbose-messages=1 --prefetch-count=1 
+```
+- `--blocking=1` is used to use blocking waiting mechanism [performance] (STRONGLY RECOMMENDED)
+- `--auto-reconnect=1` is used to auto reconnect if something is wrong with the connection [durability] (recommended)
+- `--alive-check=30` is used to custom check if connection is stuck [durability] (recommended with `blocking=1` if you have virtualization/proxies)
+- `--init-queue=1` is used to auto create queue before consuming [durability] (recommended)
+- `--verbose-messages=1` is used to not write anything about processed messages [performance] (not necessary)
+- `--prefetch-count=1` is used to limit number of messages prefetched [durability] (not necessary)
+
+
+The config to provide:
+```php
+'connections' => [
+    // ...
+
+    'rabbitmq' => [
+        // ...
+
+        'options' => [
+            // ...            
+            'queue' => [
+                'use_expiration_for_delayed_queues' => true // To create only one later-queue for any TTL
+                'declare_full_route' => true // To auto-init full route of message if you need both queue + exchange
+                'retries' => [ // To enable retries if the queue fails to push
+                    'enabled' => true,
+                    'max' => 5, // number of retries
+                    'pause_micro_seconds' => 1e6 // pause between retries
+                ],
+                
+                'channel_rpc_timeout' => 3 // To make custom alive-check work (required with `blocking=1` and --alive-check=N`)
+                'keepalive' => true // To keep the connection alive (STRONGLY RECOMMENDED with `blocking=1`)
+            ]
+        ],
+    ],
+
+    // ...    
+],
+```
+
 ## Testing
 
 Setup RabbitMQ using `docker-compose`:

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -3,6 +3,10 @@
 namespace VladimirYuldashev\LaravelQueueRabbitMQ\Console;
 
 use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Support\Str;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Consumer;
 
@@ -30,9 +34,17 @@ class ConsumeCommand extends WorkCommand
                             {--consumer-tag}
                             {--prefetch-size=0}
                             {--prefetch-count=1000}
+                            {--blocking=0 : Weather to block queue waiting or not}
+                            {--init-queue=0 : Enables init the queue before starting consuming}
+                            {--auto-reconnect=0 : Enables auto-reconnection when something is wrong with the connection}
+                            {--auto-reconnect-pause=0.5 : The pause (in seconds) before reconnecting}
+                            {--alive-check=0 : The pause (in seconds) before reconnecting}
+                            {--verbose-messages=0 : Write messages only when verbose mode is enabled}
                            ';
 
     protected $description = 'Consume messages';
+
+    protected $useVerboseForMessages = false;
 
     public function handle(): void
     {
@@ -45,6 +57,14 @@ class ConsumeCommand extends WorkCommand
         $consumer->setMaxPriority((int) $this->option('max-priority'));
         $consumer->setPrefetchSize((int) $this->option('prefetch-size'));
         $consumer->setPrefetchCount((int) $this->option('prefetch-count'));
+        $consumer->setBlocking($this->booleanOption('blocking'));
+        $consumer->setInitQueue($this->booleanOption('init-queue'));
+        $consumer->setAutoReconnect($this->booleanOption('auto-reconnect'));
+        $consumer->setAutoReconnectPause((float)$this->option('auto-reconnect-pause'));
+        $consumer->setAliveCheck((float)$this->option('alive-check'));
+
+        $consumer->setInteractWithIO($this);
+        $this->useVerboseForMessages = $this->booleanOption('verbose-messages');
 
         parent::handle();
     }
@@ -62,5 +82,46 @@ class ConsumeCommand extends WorkCommand
         ]);
 
         return Str::substr($consumerTag, 0, 255);
+    }
+
+    protected function booleanOption(string $key): bool
+    {
+        return filter_var(
+            $this->option($key),
+            FILTER_VALIDATE_BOOLEAN
+        );
+    }
+
+    /**
+     * Output worker results only in verbose mode
+     */
+    protected function listenForEvents()
+    {
+        if ($this->useVerboseForMessages) {
+            parent::listenForEvents();
+            return;
+        }
+
+        $this->laravel['events']->listen(JobFailed::class, function ($event) {
+            if ($this->output->isVerbose()) {
+                $this->writeOutput($event->job, 'failed');
+            }
+
+            $this->logFailedJob($event);
+        });
+
+        if ($this->output->isVerbose()) {
+            $this->laravel['events']->listen(JobProcessing::class, function ($event) {
+                $this->writeOutput($event->job, 'starting');
+            });
+
+            $this->laravel['events']->listen(JobProcessed::class, function ($event) {
+                $this->writeOutput($event->job, 'success');
+            });
+
+            $this->laravel['events']->listen(JobReleasedAfterException::class, function ($event) {
+                $this->writeOutput($event->job, 'released_after_exception');
+            });
+        }
     }
 }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -3,12 +3,20 @@
 namespace VladimirYuldashev\LaravelQueueRabbitMQ;
 
 use Exception;
+use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Exception\AMQPRuntimeException;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
+use PhpAmqpLib\Exception\AMQPProtocolChannelException;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 
@@ -29,11 +37,69 @@ class Consumer extends Worker
     /** @var int */
     protected $prefetchCount;
 
-    /** @var AMQPChannel */
+    /**
+     * @var bool
+     */
+    protected $blocking = false;
+
+    /**
+     * @var bool
+     */
+    protected $initQueue = false;
+
+    /**
+     * @var bool
+     */
+    protected $autoReconnect = false;
+
+    /**
+     * @var float
+     */
+    protected $autoReconnectPause = 0;
+
+    /**
+     * @var float
+     */
+    protected $aliveCheck = 0;
+
+    /**
+     * @var bool
+     */
+    protected $asyncSignalsSupported;
+
+    /**
+     * @var RabbitMQQueue
+     */
+    protected $connection = null;
+
+    /**
+     * @var AMQPChannel
+     */
     protected $channel;
 
-    /** @var object|null */
+    /**
+     * @var object|null
+     */
     protected $currentJob;
+
+    /**
+     * @var InteractsWithIO
+     */
+    protected $interactsWithIO = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(
+        QueueManager $manager,
+        Dispatcher $events,
+        ExceptionHandler $exceptions,
+        callable $isDownForMaintenance,
+        ?callable $resetScope = null
+    ) {
+        parent::__construct($manager, $events, $exceptions, $isDownForMaintenance, $resetScope);
+        $this->asyncSignalsSupported = $this->supportsAsyncSignals();
+    }
 
     public function setContainer(Container $value): void
     {
@@ -60,6 +126,39 @@ class Consumer extends Worker
         $this->prefetchCount = $value;
     }
 
+    public function setBlocking(bool $value): void
+    {
+        $this->blocking = $value;
+    }
+
+    public function setInitQueue(bool $value): void
+    {
+        $this->initQueue = $value;
+    }
+
+    public function setAutoReconnect(bool $value): void
+    {
+        $this->autoReconnect = $value;
+    }
+
+    public function setAutoReconnectPause(float $value): void
+    {
+        $this->autoReconnectPause = $value;
+    }
+
+    public function setAliveCheck(float $value): void
+    {
+        $this->aliveCheck = $value;
+    }
+
+    /**
+     * @param  InteractsWithIO  $value
+     */
+    public function setInteractWithIO($value): void
+    {
+        $this->interactsWithIO = $value;
+    }
+
     /**
      * Listen to the given queue in a loop.
      *
@@ -71,114 +170,237 @@ class Consumer extends Worker
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
-        if ($this->supportsAsyncSignals()) {
+        if ($this->asyncSignalsSupported) {
             $this->listenForSignals();
         }
 
+        $startTime = hrtime(true) / 1e9;
+        $jobsProcessed = 0;
         $lastRestart = $this->getTimestampOfLastQueueRestart();
 
-        [$startTime, $jobsProcessed] = [hrtime(true) / 1e9, 0];
+        while (true) {
+            try {
+                $this->printOutputLine('Creating new connection');
+                $this->initConnection($connectionName, $queue);
+                $status = $this->consume(
+                    $startTime,
+                    $jobsProcessed,
+                    $lastRestart,
+                    $connectionName,
+                    $queue,
+                    $options
+                );
+                if ($status !== null) {
+                    return $status;
+                }
 
-        /** @var RabbitMQQueue $connection */
-        $connection = $this->manager->connection($connectionName);
+                break;
+            } catch (AMQPExceptionInterface $exception) {
+                $this->exceptions->report($exception);
 
-        $this->channel = $connection->getChannel();
+                if (! $this->isAmqpConnectionException($exception)) {
+                    $this->kill(self::EXIT_ERROR, $options);
 
-        $this->channel->basic_qos(
-            $this->prefetchSize,
-            $this->prefetchCount,
-            false
-        );
+                    return 0;
+                } elseif (! $this->autoReconnect) {
+                    $this->kill(self::EXIT_ERROR, $options);
 
-        $jobClass = $connection->getJobClass();
+                    return 0;
+                }
+
+                $this->sleep($this->autoReconnectPause);
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return int
+     *
+     * @throws Throwable
+     */
+    protected function consume(float $startTime, int &$jobsProcessed, ?int $lastRestart, string $connectionName, string $queue, WorkerOptions $options)
+    {
+        $jobClass = $this->connection->getJobClass();
         $arguments = [];
         if ($this->maxPriority) {
             $arguments['priority'] = ['I', $this->maxPriority];
         }
 
-        $this->channel->basic_consume(
-            $queue,
-            $this->consumerTag,
-            false,
-            false,
-            false,
-            false,
-            function (AMQPMessage $message) use ($connection, $options, $connectionName, $queue, $jobClass, &$jobsProcessed): void {
-                $job = new $jobClass(
-                    $this->container,
-                    $connection,
-                    $message,
-                    $connectionName,
-                    $queue
-                );
-
-                $this->currentJob = $job;
-
-                if ($this->supportsAsyncSignals()) {
-                    $this->registerTimeoutHandler($job, $options);
+        while (true) {
+            if ($this->blocking && ! $this->daemonShouldRun($options, $connectionName, $queue)) {
+                if ($this->asyncSignalsSupported) {
+                    pcntl_signal_dispatch();
                 }
 
-                $jobsProcessed++;
-
-                $this->runJob($job, $connectionName, $options);
-
-                if ($this->supportsAsyncSignals()) {
-                    $this->resetTimeoutHandler();
+                $status = $this->pauseWorker($options, $lastRestart);
+                if ($status !== null) {
+                    return $this->stop($status, $options);
                 }
-
-                if ($options->rest > 0) {
-                    $this->sleep($options->rest);
-                }
-            },
-            null,
-            $arguments
-        );
-
-        while ($this->channel->is_consuming()) {
-            // Before reserving any jobs, we will make sure this queue is not paused and
-            // if it is we will just pause this worker for a given amount of time and
-            // make sure we do not need to kill this worker process off completely.
-            if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
-                $this->pauseWorker($options, $lastRestart);
 
                 continue;
             }
 
-            // If the daemon should run (not in maintenance mode, etc.), then we can wait for a job.
-            try {
-                $this->channel->wait(null, true, (int) $options->timeout);
-            } catch (AMQPRuntimeException $exception) {
-                $this->exceptions->report($exception);
+            $this->reinitChannelIfNeed($queue);
+            $this->channel->basic_consume(
+                $queue,
+                $this->consumerTag,
+                false,
+                false,
+                false,
+                false,
+                function (AMQPMessage $message) use ($options, $connectionName, $queue, $jobClass, &$jobsProcessed): void {
+                    $this->printOutputLine('New message is received');
+                    $job = new $jobClass(
+                        $this->container,
+                        $this->connection,
+                        $message,
+                        $connectionName,
+                        $queue
+                    );
 
-                $this->kill(self::EXIT_ERROR, $options);
-            } catch (Exception|Throwable $exception) {
-                $this->exceptions->report($exception);
+                    $this->currentJob = $job;
 
-                $this->stopWorkerIfLostConnection($exception);
-            }
+                    if ($this->asyncSignalsSupported) {
+                        $this->registerTimeoutHandler($job, $options);
+                    }
 
-            // If no job is got off the queue, we will need to sleep the worker.
-            if ($this->currentJob === null) {
-                $this->sleep($options->sleep);
-            }
+                    $jobsProcessed++;
 
-            // Finally, we will check to see if we have exceeded our memory limits or if
-            // the queue should restart based on other indications. If so, we'll stop
-            // this worker and let whatever is "monitoring" it restart the process.
-            $status = $this->stopIfNecessary(
-                $options,
-                $lastRestart,
-                $startTime,
-                $jobsProcessed,
-                $this->currentJob
+                    $this->runJob($job, $connectionName, $options);
+
+                    if ($this->asyncSignalsSupported) {
+                        $this->resetTimeoutHandler();
+                    }
+
+                    if ($options->rest > 0) {
+                        $this->sleep($options->rest);
+                    }
+
+                    $this->printOutputLine('New message is processed');
+                },
+                null,
+                $arguments
             );
 
-            if (! is_null($status)) {
-                return $this->stop($status, $options);
+            while ($this->channel->is_consuming()) {
+                // Before reserving any jobs, we will make sure this queue is not paused and
+                // if it is we will just pause this worker for a given amount of time and
+                // make sure we do not need to kill this worker process off completely.
+                if (! $this->blocking && ! $this->daemonShouldRun($options, $connectionName, $queue)) {
+                    $status = $this->pauseWorker($options, $lastRestart);
+                    if ($status !== null) {
+                        return $this->stop($status, $options);
+                    }
+
+                    continue;
+                }
+
+                // If the daemon should run (not in maintenance mode, etc.), then we can wait for a job.
+                try {
+                    $this->channel->wait(null, ! $this->blocking, $this->blocking ? $this->aliveCheck : $options->timeout);
+                } catch (AMQPTimeoutException $exception) {
+                    if ($this->blocking && $this->aliveCheck > 0) {
+                        $this->checkAlive();
+                    } else {
+                        throw $exception;
+                    }
+                } catch (AMQPExceptionInterface $exception) {
+                    throw $exception;
+                } catch (Throwable $exception) {
+                    $this->exceptions->report($exception);
+
+                    $this->stopWorkerIfLostConnection($exception);
+                }
+
+                // If no job is got off the queue, we will need to sleep the worker.
+                if (! $this->blocking && ! $this->currentJob) {
+                    $this->sleep($options->sleep);
+                }
+
+                // Finally, we will check to see if we have exceeded our memory limits or if
+                // the queue should restart based on other indications. If so, we'll stop
+                // this worker and let whatever is "monitoring" it restart the process.
+                $status = $this->stopIfNecessary(
+                    $options,
+                    $lastRestart,
+                    $startTime,
+                    $jobsProcessed,
+                    $this->currentJob
+                );
+                if ($status !== null) {
+                    return $this->stop($status, $options);
+                }
+
+                $this->currentJob = null;
             }
 
-            $this->currentJob = null;
+            if (! $this->blocking) {
+                break;
+            }
         }
+
+        return null;
+    }
+
+    /**
+     * @throws \PhpAmqpLib\Exception\AMQPProtocolChannelException
+     */
+    protected function initConnection(string $connectionName, string $queue): void
+    {
+        if ($this->connection !== null) {
+            // Reconnecting
+            $this->connection->reconnect();
+        } else {
+            /* @var RabbitMQQueue $connection */
+            $this->connection = $this->manager->connection($connectionName);
+            if (! $this->connection instanceof RabbitMQQueue) {
+                throw new Exception('Connection should implement '.RabbitMQQueue::class);
+            }
+
+            // Force disable retrying when we are in the consumer context (to avoid bad state of a job)
+            $this->connection->setDisableRetries(true);
+        }
+
+        $this->initChannel($queue);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \PhpAmqpLib\Exception\AMQPProtocolChannelException
+     */
+    protected function initChannel(string $queue)
+    {
+        if ($this->initQueue) {
+            $this->declareQueue($this->connection, $queue);
+        }
+
+        $this->channel = $this->connection->getChannel();
+        $this->channel->basic_qos(
+            $this->prefetchSize,
+            $this->prefetchCount,
+            null
+        );
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws \PhpAmqpLib\Exception\AMQPProtocolChannelException
+     */
+    protected function reinitChannelIfNeed(string $queue)
+    {
+        // Check that channel is active
+        // Connection can close channel because of reconnection mechanism itself
+        if ($this->channel->is_open()) {
+            return false;
+        }
+
+        $this->initChannel($queue);
+
+        return true;
     }
 
     /**
@@ -193,18 +415,226 @@ class Consumer extends Worker
     }
 
     /**
-     * Stop listening and bail out of the script.
-     *
-     * @param  int  $status
-     * @param  WorkerOptions|null  $options
-     * @return int
+     * {@inheritdoc}
+     */
+    protected function runJob($job, $connectionName, WorkerOptions $options)
+    {
+        if (! $this->blocking) {
+            return parent::runJob($job, $connectionName, $options);
+        }
+
+        try {
+            return $this->process($connectionName, $job, $options);
+        } catch (Throwable $e) {
+            // Throw exception to call reconnect
+            if ($this->isAmqpConnectionException($e)) {
+                throw $e;
+            }
+
+            $this->exceptions->report($e);
+
+            $this->stopWorkerIfLostConnection($e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function listenForSignals()
+    {
+        if (! $this->blocking) {
+            parent::listenForSignals();
+
+            return;
+        }
+
+        // Support pause/exit for blocking mode
+        pcntl_async_signals(true);
+        pcntl_signal(SIGHUP, [$this, 'quitSignalHandler']);
+        pcntl_signal(SIGTERM, [$this, 'quitSignalHandler']);
+        pcntl_signal(SIGQUIT, [$this, 'quitSignalHandler']);
+
+        pcntl_signal(SIGUSR2, function () {
+            $this->printOutputLine('SIGUSR2('.SIGUSR2.') is received. Pause this worker', 'warning');
+            $this->paused = true;
+            $this->channel->basic_cancel($this->consumerTag);
+        });
+
+        pcntl_signal(SIGCONT, function () {
+            $this->printOutputLine('SIGCONT('.SIGCONT.') is received. Unpause this worker', 'warning');
+            $this->paused = false;
+        });
+    }
+
+    /**
+     * @param  null  $sigInfo
+     */
+    public function quitSignalHandler($signal, $sigInfo = null): void
+    {
+        $signalName = null;
+        switch ($signal) {
+            case SIGHUP:
+                $signalName = 'SIGHUP';
+                break;
+            case SIGTERM:
+                $signalName = 'SIGTERM';
+                break;
+            case SIGQUIT:
+                $signalName = 'SIGQUIT';
+                break;
+        }
+
+        $this->printOutputLine("$signalName($signal) is received. Activate the `shouldQuit` option", 'warning');
+        $this->shouldQuit = true;
+        $this->channel->basic_cancel($this->consumerTag);
+    }
+
+    /**
+     * @throws AMQPProtocolChannelException
+     */
+    protected function declareQueue(RabbitMQQueue $queue, ?string $queueName): void
+    {
+        // When the queue already exists, just return.
+        if ($queue->isQueueExists($queueName)) {
+            return;
+        }
+
+        // Create a queue
+        $queue->declareQueueByConfig($queueName);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function stop($status = 0, $options = null)
     {
+        if (is_array($status)) {
+            [$status, $reason] = $status;
+        } else {
+            $reason = null;
+        }
+
+        $reason = $reason ?: 'no reason';
+        $this->printOutputLine('Stopping this worker with status '.$status.' because of '.$reason, 'error');
+
         // Tell the server you are going to stop consuming.
-        // It will finish up the last message and not send you any more.
+        // It will finish up the last message and not send you anymore.
         $this->channel->basic_cancel($this->consumerTag, false, true);
 
         return parent::stop($status, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function kill($status = 0, $options = null)
+    {
+        $this->printOutputLine('Killing this worker with status '.$status, 'error');
+        parent::kill($status, $options);
+    }
+
+    /**
+     * Same as parent, but with logs.
+     * {@inheritDoc}
+     */
+    public function stopIfNecessary(WorkerOptions $options, $lastRestart, $startTime = 0, $jobsProcessed = 0, $job = null)
+    {
+        return match (true) {
+            $this->shouldQuit => [static::EXIT_SUCCESS, '`shouldQuit` is active'],
+            $this->memoryExceeded($options->memory) => [static::EXIT_MEMORY_LIMIT, 'exceeded memory-limit'],
+            $this->queueShouldRestart($lastRestart) => [static::EXIT_SUCCESS, 'should-restart'],
+            $options->stopWhenEmpty && is_null($job) => [static::EXIT_SUCCESS, '`stopWhenEmpty` option is active'],
+            $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => [static::EXIT_SUCCESS, 'reached max working time'],
+            $options->maxJobs && $jobsProcessed >= $options->maxJobs => [static::EXIT_SUCCESS, 'reached max processed jobs'],
+            default => null
+        };
+    }
+
+    /**
+     * Same as parent, but with logs.
+     * {@inheritDoc}
+     */
+    protected function registerTimeoutHandler($job, WorkerOptions $options)
+    {
+        // We will register a signal handler for the alarm signal so that we can kill this
+        // process if it is running too long because it has frozen. This uses the async
+        // signals supported in recent versions of PHP to accomplish it conveniently.
+        pcntl_signal(SIGALRM, function () use ($job, $options) {
+            $this->printOutputLine('SIGALRM('.SIGALRM.') is received (timeout). Cancelling a job and killing this worker', 'error');
+
+            if ($job) {
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timeoutExceededException($job)
+                );
+
+                $this->markJobAsFailedIfWillExceedMaxExceptions(
+                    $job->getConnectionName(), $job, $e
+                );
+
+                $this->markJobAsFailedIfItShouldFailOnTimeout(
+                    $job->getConnectionName(), $job, $e
+                );
+
+                $this->events->dispatch(new JobTimedOut(
+                    $job->getConnectionName(), $job
+                ));
+            }
+
+            $this->kill(static::EXIT_ERROR, $options);
+        }, true);
+
+        pcntl_alarm(
+            max($this->timeoutForJob($job, $options), 0)
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    protected function printOutputLine(string $message, string $type = 'comment')
+    {
+        if (! $this->interactsWithIO) {
+            return false;
+        }
+
+        $message = sprintf(
+            '[%s] %s',
+            date('Y-m-d H:i:s.u'),
+            $message
+        );
+        switch ($type) {
+            case 'comment':
+                $this->interactsWithIO->line($message, null, OutputInterface::VERBOSITY_VERBOSE);
+                break;
+            case 'warning':
+                $this->interactsWithIO->warn($message, OutputInterface::VERBOSITY_NORMAL);
+                break;
+            default:
+                $this->interactsWithIO->error($message, OutputInterface::VERBOSITY_NORMAL);
+                break;
+        }
+
+        return true;
+    }
+
+    protected function isAmqpConnectionException(Throwable $exception): bool
+    {
+        return $exception instanceof AMQPExceptionInterface;
+    }
+
+    protected function checkAlive(): void
+    {
+        try {
+            // We need to call any command that has a response, and we can wait for it.
+            // If there is no response, we consider the current connection dead
+            // WARNING: It works ONLY if `channel_rpc_timeout` is greater than 0
+            $this->channel->basic_qos(
+                $this->prefetchSize,
+                $this->prefetchCount,
+                null
+            );
+        } catch (AMQPTimeoutException $exception) {
+            throw new AMQPTimeoutException('Custom alive check failed', $exception->getTimeout(), $exception->getCode(), $exception);
+        }
     }
 }

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -37,6 +37,8 @@ class ConfigFactory
 
             self::getHostFromConfig($connectionConfig, $config);
             self::getHeartbeatFromConfig($connectionConfig, $config);
+            self::getKeepAliveFromConfig($connectionConfig, $config);
+            self::getChannelRpcTimeoutConfig($connectionConfig, $config);
             self::getNetworkProtocolFromConfig($connectionConfig, $config);
         });
     }
@@ -90,6 +92,22 @@ class ConfigFactory
 
         if (is_numeric($heartbeat) && intval($heartbeat) > 0) {
             $connectionConfig->setHeartbeat((int) $heartbeat);
+        }
+    }
+
+    protected static function getKeepAliveFromConfig(AMQPConnectionConfig $connectionConfig, array $config): void
+    {
+        $keepalive = Arr::get($config, self::CONFIG_OPTIONS.'.keepalive');
+        if (is_bool($keepalive)) {
+            $connectionConfig->setKeepalive($keepalive);
+        }
+    }
+
+    protected static function getChannelRpcTimeoutConfig(AMQPConnectionConfig $connectionConfig, array $config): void
+    {
+        $timeout = Arr::get($config, self::CONFIG_OPTIONS.'.channel_rpc_timeout');
+        if (is_numeric($timeout)) {
+            $connectionConfig->setChannelRPCTimeout((float)$timeout);
         }
     }
 

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -45,7 +45,7 @@ class QueueConfig
     protected array $retryOptions = [
         'enable' => false,
         'max' => 5,
-        'pause_ms' => 1e6,
+        'pause_micro_seconds' => 1e6,
     ];
 
     protected array $options = [];

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -30,6 +30,8 @@ class QueueConfig
 
     protected string $exchangeRoutingKey = '%s';
 
+    protected bool $declareFullRoute = false;
+
     protected bool $rerouteFailed = false;
 
     protected string $failedExchange = '';
@@ -360,6 +362,18 @@ class QueueConfig
     public function setLogChannelName(?string $logChannelName): QueueConfig
     {
         $this->logChannelName = $logChannelName;
+
+        return $this;
+    }
+
+    public function isDeclareFullRoute(): bool
+    {
+        return $this->declareFullRoute;
+    }
+
+    public function setDeclareFullRoute(bool $declareFullRoute): QueueConfig
+    {
+        $this->declareFullRoute = $declareFullRoute;
 
         return $this;
     }

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -38,6 +38,14 @@ class QueueConfig
 
     protected bool $quorum = false;
 
+    protected ?string $logChannelName = null;
+
+    protected array $retryOptions = [
+        'enable' => false,
+        'max' => 5,
+        'pause_ms' => 1e6,
+    ];
+
     protected array $options = [];
 
     /**
@@ -328,6 +336,30 @@ class QueueConfig
     public function setUseExpirationForDelayedQueues(bool $useExpirationForDelayedQueues): QueueConfig
     {
         $this->useExpirationForDelayedQueues = $useExpirationForDelayedQueues;
+
+        return $this;
+    }
+
+    public function getRetryOptions(): array
+    {
+        return $this->retryOptions;
+    }
+
+    public function setRetryOptions(array $retryOptions): QueueConfig
+    {
+        $this->retryOptions = $retryOptions;
+
+        return $this;
+    }
+
+    public function getLogChannelName(): ?string
+    {
+        return $this->logChannelName;
+    }
+
+    public function setLogChannelName(?string $logChannelName): QueueConfig
+    {
+        $this->logChannelName = $logChannelName;
 
         return $this;
     }

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -20,6 +20,8 @@ class QueueConfig
 
     protected bool $queueDurable = true;
 
+    protected bool $useExpirationForDelayedQueues = false;
+
     protected int $queueMaxPriority = 2;
 
     protected string $exchange = '';
@@ -314,6 +316,18 @@ class QueueConfig
     public function setQueueAutoDelete(bool $queueAutoDelete): QueueConfig
     {
         $this->queueAutoDelete = $queueAutoDelete;
+
+        return $this;
+    }
+
+    public function isUseExpirationForDelayedQueues(): bool
+    {
+        return $this->useExpirationForDelayedQueues;
+    }
+
+    public function setUseExpirationForDelayedQueues(bool $useExpirationForDelayedQueues): QueueConfig
+    {
+        $this->useExpirationForDelayedQueues = $useExpirationForDelayedQueues;
 
         return $this;
     }

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -16,6 +16,10 @@ class QueueConfig
 
     protected bool $cacheDeclared = true;
 
+    protected bool $queueAutoDelete = false;
+
+    protected bool $queueDurable = true;
+
     protected int $queueMaxPriority = 2;
 
     protected string $exchange = '';
@@ -286,6 +290,30 @@ class QueueConfig
     public function setCacheDeclared(bool $cacheDeclared): QueueConfig
     {
         $this->cacheDeclared = $cacheDeclared;
+
+        return $this;
+    }
+
+    public function isQueueDurable(): bool
+    {
+        return $this->queueDurable;
+    }
+
+    public function setQueueDurable(bool $queueDurable): QueueConfig
+    {
+        $this->queueDurable = $queueDurable;
+
+        return $this;
+    }
+
+    public function isQueueAutoDelete(): bool
+    {
+        return $this->queueAutoDelete;
+    }
+
+    public function setQueueAutoDelete(bool $queueAutoDelete): QueueConfig
+    {
+        $this->queueAutoDelete = $queueAutoDelete;
 
         return $this;
     }

--- a/src/Queue/QueueConfig.php
+++ b/src/Queue/QueueConfig.php
@@ -14,6 +14,8 @@ class QueueConfig
 
     protected bool $prioritizeDelayed = false;
 
+    protected bool $cacheDeclared = true;
+
     protected int $queueMaxPriority = 2;
 
     protected string $exchange = '';
@@ -274,5 +276,17 @@ class QueueConfig
     protected function toBoolean($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    public function isCacheDeclared(): bool
+    {
+        return $this->cacheDeclared;
+    }
+
+    public function setCacheDeclared(bool $cacheDeclared): QueueConfig
+    {
+        $this->cacheDeclared = $cacheDeclared;
+
+        return $this;
     }
 }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -68,6 +68,15 @@ class QueueConfigFactory
             $queueConfig->setQuorum($quorum);
         }
 
+        // Feature: Retries with Logs
+        if ($retriesOption = Arr::pull($queueOptions, 'retries')) {
+            $queueConfig->setRetryOptions($retriesOption);
+        }
+        if (array_key_exists('log_channel', $queueOptions)) {
+            $queueConfig->setLogChannelName($queueOptions['log_channel']);
+            unset($queueOptions['log_channel']);
+        }
+
         // Feature: Caching
         if (array_key_exists('cache_declared', $queueOptions)) {
             $queueConfig->setCacheDeclared($queueOptions['cache_declared']);

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -68,6 +68,12 @@ class QueueConfigFactory
             $queueConfig->setQuorum($quorum);
         }
 
+        // Feature: Caching
+        if (array_key_exists('cache_declared', $queueOptions)) {
+            $queueConfig->setCacheDeclared($queueOptions['cache_declared']);
+            unset($queueOptions['cache_declared']);
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -100,6 +100,12 @@ class QueueConfigFactory
             unset($queueOptions['use_expiration_for_delayed_queues']);
         }
 
+        // Feature: Declare full route
+        if (array_key_exists('declare_full_route', $queueOptions)) {
+            $queueConfig->setDeclareFullRoute($queueOptions['declare_full_route']);
+            unset($queueOptions['declare_full_route']);
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -74,6 +74,17 @@ class QueueConfigFactory
             unset($queueOptions['cache_declared']);
         }
 
+        // Feature: Queue flags
+        $queueFlags = Arr::pull($queueOptions, 'flags');
+        if ($queueFlags) {
+            if (array_key_exists('durable', $queueFlags)) {
+                $queueConfig->setQueueDurable($queueFlags['durable']);
+            }
+            if (array_key_exists('auto_delete', $queueFlags)) {
+                $queueConfig->setQueueAutoDelete($queueFlags['auto_delete']);
+            }
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/QueueConfigFactory.php
+++ b/src/Queue/QueueConfigFactory.php
@@ -85,6 +85,12 @@ class QueueConfigFactory
             }
         }
 
+        // Feature: Another strategy for later tasks
+        if (array_key_exists('use_expiration_for_delayed_queues', $queueOptions)) {
+            $queueConfig->setUseExpirationForDelayedQueues($queueOptions['use_expiration_for_delayed_queues']);
+            unset($queueOptions['use_expiration_for_delayed_queues']);
+        }
+
         // All extra options not defined
         $queueConfig->setOptions($queueOptions);
     }

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -976,4 +976,18 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
         return $destination;
     }
+
+    /**
+     * @param \DateTimeInterface|\DateInterval|int|float $delay
+     * @return float|int
+     */
+    protected function secondsUntil($delay)
+    {
+        // Support ms
+        if (is_float($delay)) {
+            return $delay;
+        }
+
+        return parent::secondsUntil($delay);
+    }
 }

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -412,7 +412,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
             $channel->close();
 
             $cfg = $this->getConfig();
-            if ($cfg->isCacheDeclared()) {
+            if ($cfg->isCacheDeclared() && ! $cfg->isQueueAutoDelete()) {
                 $this->cacheDeclaredQueue($queueName);
             }
 
@@ -600,6 +600,20 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     }
 
     /**
+     * @param string $destination
+     * @return void
+     */
+    public function declareQueueByConfig(string $destination): void
+    {
+        $this->declareQueue(
+            $destination,
+            $this->getConfig()->isQueueDurable(),
+            $this->getConfig()->isQueueAutoDelete(),
+            $this->getQueueArguments($destination)
+        );
+    }
+
+    /**
      * Get the Queue arguments.
      */
     protected function getQueueArguments(string $destination): array
@@ -722,7 +736,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         }
 
         // Create a queue for amq.direct publishing.
-        $this->declareQueue($destination, true, false, $this->getQueueArguments($destination));
+        $this->declareQueueByConfig($destination);
     }
 
     /**

--- a/tests/Feature/Commands/ConsumeCommandTest.php
+++ b/tests/Feature/Commands/ConsumeCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Feature\Commands;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Wire\IO\StreamIO;
+use PHPUnit\Framework\Attributes\TestWith;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Functional\TestCase;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestJob;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestJobCallService;
+
+class ConsumeCommandTest extends TestCase
+{
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function test_consume_one_job(bool $blocking): void
+    {
+        $queueNameAndConnection = Str::random();
+        $this->app['config']->set("queue.connections.$queueNameAndConnection", $this->app['config']->get('queue.connections.rabbitmq'));
+        $this->app['config']->set("queue.connections.$queueNameAndConnection.queue", $queueNameAndConnection);
+
+        $service = $this->createMock(TestJob::class);
+        $serviceName = Str::random();
+        $this->app->singleton($serviceName, fn() => $service);
+        $service
+            ->expects($this->once())
+            ->method('handle');
+
+        Queue::push(new TestJobCallService($serviceName, 'handle'), '', $queueNameAndConnection);
+        $blocking = (int)$blocking;
+        $this->artisan("rabbitmq:consume $queueNameAndConnection --max-jobs=1 --blocking=$blocking");
+    }
+
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function test_consume_with_retry(bool $blocking): void
+    {
+        $queueNameAndConnection = Str::random();
+        $this->app['config']->set("queue.connections.$queueNameAndConnection", $this->app['config']->get('queue.connections.rabbitmq'));
+        $this->app['config']->set("queue.connections.$queueNameAndConnection.queue", $queueNameAndConnection);
+
+        /** @var RabbitMQQueue $connection */
+        $connection = Queue::connection($queueNameAndConnection);
+
+        // First job does nothing
+        $service1 = $this->createMock(TestJob::class);
+        $serviceName1 = Str::random();
+        $this->app->singleton($serviceName1, fn() => $service1);
+        $service1
+            ->expects($this->once())
+            ->method('handle');
+        Queue::push(new TestJobCallService($serviceName1, 'handle'), '', $queueNameAndConnection);
+
+        // Second job must fail first time (by breaking channel) and be success second time
+        $service2 = (object)[];
+        $numberOfCalls = 0;
+        $service2->callback = function () use (&$numberOfCalls, $connection) {
+            $numberOfCalls++;
+            if ($numberOfCalls === 1) {
+                $connection->getChannel()->close();
+            }
+        };
+        $serviceName2 = Str::random();
+        $this->app->singleton($serviceName2, fn() => $service2);
+
+        Queue::push(new TestJobCallService($serviceName2, 'callback'), '', $queueNameAndConnection);
+
+        $blocking = (int)$blocking;
+        $this->artisan("rabbitmq:consume $queueNameAndConnection --max-jobs=2 --blocking=$blocking --auto-reconnect=1 --verbose-messages=1 --init-queue=1");
+        $this->assertEquals(2, $numberOfCalls);
+    }
+
+    public function test_consume_blocking_alive_check(): void
+    {
+        $this->markTestSkippedUnless(extension_loaded('sockets'), 'Sockets extension is required');
+
+        $handler = $this->createMock(ExceptionHandler::class);
+        $handler
+            ->expects($this->once())
+            ->method('report')
+            ->willReturnCallback(function (AMQPTimeoutException $exception) {
+                $this->assertEquals('Custom alive check failed', $exception->getMessage());
+            });
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $queueNameAndConnection = Str::random();
+        $this->app['config']->set("queue.connections.$queueNameAndConnection", $this->app['config']->get('queue.connections.rabbitmq'));
+        $this->app['config']->set("queue.connections.$queueNameAndConnection.queue", $queueNameAndConnection);
+        $this->app['config']->set("queue.connections.$queueNameAndConnection.options.channel_rpc_timeout", 1);
+        $this->app['config']->set("queue.connections.$queueNameAndConnection.options.keepalive", true);
+
+        /** @var RabbitMQQueue $connection */
+        $connection = Queue::connection($queueNameAndConnection);
+
+        $port = random_int(10000, 50000);
+        $pathToSocksFile = __DIR__ . '/../../Script/socket_fake.php';
+        $descriptors = [
+            ['pipe', 'r'], // stdin
+            ['pipe', 'w'], // stdout
+            ['pipe', 'w'], // stderr
+        ];
+        $proc = proc_open("php $pathToSocksFile $port", $descriptors, $pipes);
+        sleep(1);
+        $status = proc_get_status($proc);
+        if (!$status['running']) {
+            throw new \Exception('Cant make fake socket' . fread($pipes[1], 8192));
+        }
+
+        try {
+            $service = (object)[];
+            $numberOfCalls1 = 0;
+            // Listen and do nothing
+            $service->callback1 = function () use (&$numberOfCalls1, $connection, $port) {
+                $numberOfCalls1++;
+
+                // Emulate problems with connection
+                $input = $this->callProperty($connection->getConnection(), 'input');
+                $className = get_class($input);
+                $reflection = new \ReflectionClass($className);
+
+                $newStream = new StreamIO('127.0.0.1', $port, 1, 1);
+                $newStream->connect();
+
+                $property = $reflection->getProperty('io');
+                $property->setAccessible(true);
+                $property->setValue($input, $newStream);
+            };
+            $numberOfCalls2 = 0;
+            $service->callback2 = function () use (&$numberOfCalls2) {
+                // do nothing
+                $numberOfCalls2++;
+            };
+            $serviceName = Str::random();
+            $this->app->singleton($serviceName, fn() => $service);
+            $connection->push(new TestJobCallService($serviceName, 'callback1'), '', $queueNameAndConnection);
+            $connection->push(new TestJobCallService($serviceName, 'callback2'), '', $queueNameAndConnection);
+
+            $this->artisan("rabbitmq:consume $queueNameAndConnection --max-jobs=2 --blocking=1 --auto-reconnect=1 --alive-check=1 --init-queue=1");
+            $this->assertEquals(1, $numberOfCalls1);
+            $this->assertEquals(1, $numberOfCalls2);
+            $this->assertEquals(0, $connection->size($queueNameAndConnection));
+        } finally {
+            proc_terminate($proc);
+            proc_close($proc);
+        }
+    }
+}

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -483,4 +483,27 @@ abstract class TestCase extends BaseTestCase
             }
         }
     }
+
+    public function test_full_route_declare(): void
+    {
+        // Make another connection
+        $this->app['config']->set('queue.connections.rabbitmq2', $this->app['config']->get('queue.connections.rabbitmq'));
+        $this->app['config']->set('queue.connections.rabbitmq2.options.queue.declare_full_route', true);
+
+        $queue = Str::random();
+        $exchange = Str::random();
+
+        /** @var RabbitMQQueue $connection */
+        $connection = Queue::connection('rabbitmq2');
+        $this->assertFalse($connection->isQueueExists($queue));
+        $this->assertFalse($connection->isExchangeExists($exchange));
+
+        $connection->pushRaw('data', $queue, [
+            'exchange' => $exchange,
+        ]);
+
+        $this->assertTrue($connection->isQueueExists($queue));
+        $this->assertTrue($connection->isExchangeExists($exchange));
+        $this->assertSame(1, $connection->size($queue));
+    }
 }

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -489,7 +489,7 @@ abstract class TestCase extends BaseTestCase
         $this->app['config']->set('queue.connections.rabbitmq2.options.queue.retries', [
             'enabled' => $enableRetries,
             'max' => 1,
-            'pause_ms' => 1
+            'pause_micro_seconds' => 1
         ]);
 
         /** @var RabbitMQQueue $connection */

--- a/tests/Functional/RabbitMQQueueTest.php
+++ b/tests/Functional/RabbitMQQueueTest.php
@@ -312,6 +312,7 @@ class RabbitMQQueueTest extends BaseTestCase
 
     public function test_delay_queue_arguments(): void
     {
+        $this->app['config']->set('queue.connections.rabbitmq.options.queue.use_expiration_for_delayed_queues', true);
         $name = Str::random();
         $ttl = 12000;
 
@@ -319,9 +320,7 @@ class RabbitMQQueueTest extends BaseTestCase
         $actual = $this->callMethod($queue, 'getDelayQueueArguments', [$name, $ttl]);
         $expected = [
             'x-dead-letter-exchange' => '',
-            'x-dead-letter-routing-key' => $name,
-            'x-message-ttl' => $ttl,
-            'x-expires' => $ttl * 2,
+            'x-dead-letter-routing-key' => $name
         ];
         $this->assertEquals(array_keys($expected), array_keys($actual));
         $this->assertEquals(array_values($expected), array_values($actual));

--- a/tests/Functional/RabbitMQQueueTest.php
+++ b/tests/Functional/RabbitMQQueueTest.php
@@ -4,6 +4,7 @@ namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Functional;
 
 use Illuminate\Support\Str;
 use PhpAmqpLib\Exchange\AMQPExchangeType;
+use PHPUnit\Framework\Attributes\TestWith;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Functional\TestCase as BaseTestCase;
 
@@ -202,8 +203,11 @@ class RabbitMQQueueTest extends BaseTestCase
         $this->assertTrue($this->callProperty($queue, 'config')->isQuorum());
     }
 
-    public function test_declare_delete_exchange(): void
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function test_declare_delete_exchange(bool $cache): void
     {
+        $this->app['config']->set('queue.connections.rabbitmq.options.queue.cache_declared', $cache);
         $queue = $this->connection();
 
         $name = Str::random();
@@ -212,13 +216,18 @@ class RabbitMQQueueTest extends BaseTestCase
 
         $queue->declareExchange($name);
         $this->assertTrue($queue->isExchangeExists($name));
+        $this->assertEquals($cache, $this->callMethod($queue, 'isExchangeDeclared', [$name]));
 
         $queue->deleteExchange($name);
+        $this->assertFalse($this->callMethod($queue, 'isExchangeDeclared', [$name]));
         $this->assertFalse($queue->isExchangeExists($name));
     }
 
-    public function test_declare_delete_queue(): void
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function test_declare_delete_queue(bool $cache): void
     {
+        $this->app['config']->set('queue.connections.rabbitmq.options.queue.cache_declared', $cache);
         $queue = $this->connection();
 
         $name = Str::random();
@@ -227,8 +236,10 @@ class RabbitMQQueueTest extends BaseTestCase
 
         $queue->declareQueue($name);
         $this->assertTrue($queue->isQueueExists($name));
+        $this->assertEquals($cache, $this->callMethod($queue, 'isQueueDeclared', [$name]));
 
         $queue->deleteQueue($name);
+        $this->assertFalse($this->callMethod($queue, 'isQueueDeclared', [$name]));
         $this->assertFalse($queue->isQueueExists($name));
     }
 

--- a/tests/Mocks/TestJobCallService.php
+++ b/tests/Mocks/TestJobCallService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class TestJobCallService implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public $service;
+    public $method;
+
+    public function __construct(string $service, string $method)
+    {
+        $this->service = $service;
+        $this->method = $method;
+    }
+
+    public function handle(): void
+    {
+        $service = app($this->service);
+        if (method_exists($service, $this->method)) {
+            $service->{$this->method}();
+        } else {
+            $callback = $service->{$this->method};
+            $callback();
+        }
+    }
+}

--- a/tests/Script/socket_fake.php
+++ b/tests/Script/socket_fake.php
@@ -1,0 +1,23 @@
+<?php
+
+
+if (($sock = socket_create(AF_INET, SOCK_STREAM, 0)) === false) {
+    echo "socket_create() failed: reason: " . socket_strerror(socket_last_error()) . "\n";
+    die;
+}
+
+if (socket_bind($sock, '127.0.0.1', $argv[1]) === false) {
+    echo "socket_bind() failed: reason: " . socket_strerror(socket_last_error($sock)) . "\n";
+    die;
+}
+
+if (socket_listen($sock, 5) === false) {
+    echo "socket_listen() failed: reason: " . socket_strerror(socket_last_error($sock)) . "\n";
+    die;
+}
+
+do {
+    // Just read and do nothing
+    $buf = socket_read($sock, 10, PHP_NORMAL_READ);
+    usleep(10000);
+} while (true);


### PR DESCRIPTION
I'm glad to introduce a lot of features that were made in the driver working on other projects.

Here is the short list:
1. The `blocking` mode option [Consumer]
2. The auto-reconnection option [Consumer]
3. The initializing queue option [Consumer]
4. The alive-check option [Consumer]
5. More debug/error messages [Consumer]
6. The verbose-messages option [Consumer]
7. Retry options [Queue]
8. Another expiration strategy [Queue]
9. Support `ttl` less than a secong [Queue]
10. Option to cache declared [Queue]
11. Option to declare full route [Queue]

Some of the features were added to improve a perfomance of hanling messages using Consumer, and the others were added to improve durability.

There options are production ready (I migrated them from the v13, so there could be some bugs becasue of that).
These changes don't break anything and disabled by default (except the point 5 about new messages)
Now let me explain why here a lof ot options added.

## Improving the Consumer
### Increasing perfomance 
In the default mode (non-blocking) when you don't have any messages in a queue the consumer tries to get a job, and if gets nothing it sleeps, but while it sleeps we can get a job in a queue and that job will wait, so we lose a lot of perfomance and the consumer consumes resources like CPU. To fix the problem **the blocking** mode was added.

When you use blocking mode the worker just waits for some time (or forever) for new messages, and while it waits it consumes no resources and when a job comes the worker gets it ASAP and starts working on it.

And the last one about perfomance: in the production we don't need any simple logs about successfuly processed jobs, but about errors. To fix it the **verbose-messages option** was added, you can use it to write messages ONLY if you start worker in the verbose mode (`-v`)

### Increasing durability
We don't live in the perfect world, shit happens sometime and we need to try to handle as much as we can.

To increase the Consumber durability we need to enable the **auto-reconnection option**. 
When something is wrong with the connection the consumer will automatically reconnect. Also we can use `initializing queue option`, because if the problem happens because of the RabbitMQ and the RabbitMQ restarted (you might don't have anything in it) you will get an error after reconnecting becasue the queus doesn't exist anymore.

When you use the **blocking mode** the connection can stuck in some strange state (the consumer works, the RabbitMQ sees the consumer, but messages don't reach the consumer at all), it could happen when you use a complex architecture with vurtial machines and/or proxies. To check that the connection is stuck we must call some action and wait for the response, for this the **alive-check option** was added. Just set N seconds and the consumer will check that all is OK with the connection every N seconds of working (it happens when NO messages comes in N seconds, so this doesn't affect the perfomance a lot).
Also the `keepalive` option must be enabled for the blocking mode, that's why it's added to the options.

And the last thing for the consumer: I added more logs in it to simplify an investigation about what happened, because sometimes the consumer dies and you don't get anything about what was going on (maybe it was stopped because of some options, maybe it was killed by the system)

## Improving the Queue
First of all I want to speak about the **option to cache declared**. The origial code doesn't have it and it caches all declared exchanges and queues in the memory, but it's completely WRONG (see the section about **auto-reconnection option** above), because the original code doesn't handle any problems with the connection and don't clear them in the memory. Now it's fixed and the option was added just in case to simplify any investigations of some problems of caching (useful with the Laravel Octane).

The **retry options** was added to automatically reconnect and try again if we get some problems while we send messages, it helps to avoid problems during short temporary network problems. (Maybe it's better to make another class for it, but now it's included in the Queue class)

The **another expiration strategy** was added to impove latering messages. The original strategy creates a lot of queues (one queue per TTL), but the new one just uses the [expiration](https://www.rabbitmq.com/docs/ttl#per-message-ttl-in-publishers) option of messages, and the latering messages will become more effective with this option enabled.

The **option to declare full route** was added to improve durability and stability. If you face some problems with connection and the RabbitMQ lost everything you might want to restore the full route of message, right? So, you can enable this option and before first sending the Queue class will declare exchange + queue + bind them, and you will get all things work.

## What else can be improved
- I think we need to refactor README and describe all possible options.
- We need to add more options for connections and handle all of them (see https://github.com/php-amqplib/php-amqplib/blob/master/PhpAmqpLib/Connection/AMQPConnectionConfig.php)


## Affected PRs
- https://github.com/vyuldashev/laravel-queue-rabbitmq/pull/414 can be closed becase of **blocking mode** added
- https://github.com/vyuldashev/laravel-queue-rabbitmq/pull/612 must be fixed accorging to added RPC timeout
- https://github.com/vyuldashev/laravel-queue-rabbitmq/pull/627  must be fixed accorging to the new expiration strategy added

## Affected issues
- https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/630 might be affected and solved because of **auto-retries** added in the core
- https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/596 might be affected and solved because of **auto-retries** added in the core
- https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/598 will be resolved

