### PR TITLE
Delay queues always type "classic"

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -627,6 +627,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     protected function getDelayQueueArguments(string $destination, int $ttl): array
     {
         return [
+            'x-queue-type' => 'classic',
             'x-dead-letter-exchange' => $this->getExchange(),
             'x-dead-letter-routing-key' => $this->getRoutingKey($destination),
             'x-message-ttl' => $ttl,


### PR DESCRIPTION
Since quorum queues for example, do not update the TTL and will be removed when the ttl since the first message will be removed and you will lose later messages with the same delay.

For example;
A message with a 2 second delay, creates a queue with TTL of 4 seconds. FIne!
A second message with the same delay does not update the TTL of the queue (when quorum type)
Even more messages dispatched.. Will not update the TTL.
After 4 seconds, the queue is deleted automatically and you will lose messages which has not been re-routed the de "normal" queue.

Reproduce;
- Create a "default" quorum queue to dispatch messages on
- Dispatch 20 messages in a loop with a 2 sec delay
- Watch the delay queue in rabbitmq and see not all messages ending up in the default queue

```php
for($i = 0; $i < 20; $i++) {
    TestJob::dispatch()->delay(2);
    sleep(rand(1, 5));
}
```

After this fix, the queue exists all the time, or gets deleted and recreated successfully and you will not lose any messages.