### PR TITLE
Change getQueueArguments to public and allow custom failed exchange to be passed

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -597,7 +597,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     /**
      * Get the Queue arguments.
      */
-    protected function getQueueArguments(string $destination): array
+    public function getQueueArguments(string $destination, ?string $failedExchange = null): array
     {
         $arguments = [];
 
@@ -610,7 +610,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         }
 
         if ($this->getRabbitMQConfig()->isRerouteFailed()) {
-            $arguments['x-dead-letter-exchange'] = $this->getFailedExchange();
+            $arguments['x-dead-letter-exchange'] = $this->getFailedExchange($failedExchange);
             $arguments['x-dead-letter-routing-key'] = $this->getFailedRoutingKey($destination);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ abstract class TestCase extends BaseTestCase
      * Will result in a fatal error if removed - don't know why.
      */
     public static $latestResponse = null;
-    
+
     protected function getPackageProviders($app): array
     {
         return [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,11 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * Will result in a fatal error if removed - don't know why.
+     */
+    public static $latestResponse = null;
+    
     protected function getPackageProviders($app): array
     {
         return [


### PR DESCRIPTION
When declaring custom queues it's nice to be able to use the existing queue arguments method for handling failed jobs.