### PR TITLE
Introduce the JobPending event that fires before the job is added to …the queue (pushRaw), allowing job metadata to be written (in RedisJobRepository::pushed) before any worker can pick up the job.

### DIFF
--- a/src/Horizon/RabbitMQQueue.php
+++ b/src/Horizon/RabbitMQQueue.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Events\JobDeleted;
+use Laravel\Horizon\Events\JobPending;
 use Laravel\Horizon\Events\JobPushed;
 use Laravel\Horizon\Events\JobReserved;
 use Laravel\Horizon\JobPayload;
@@ -49,6 +50,8 @@ class RabbitMQQueue extends BaseRabbitMQQueue
     public function pushRaw($payload, $queue = null, array $options = []): int|string|null
     {
         $payload = (new JobPayload($payload))->prepare($this->lastPushed ?? null)->value;
+
+        $this->event($this->getQueue($queue), new JobPending($payload));
 
         return tap(parent::pushRaw($payload, $queue, $options), function () use ($queue, $payload): void {
             $this->event($this->getQueue($queue), new JobPushed($payload));


### PR DESCRIPTION
The issue #648 describes a problem was fixed upstream in Horizon by [this](https://github.com/laravel/horizon/pull/1680/changes/d05dc5c0744f75bdb24cf15930ebc08c564ca191) pull request.

This pull request now also introduces the Event `JobPushed` which is emitted during `pushRaw`.