### PR TITLE
Add handling for setting connection name and make config publishable

### DIFF
--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -9,7 +9,7 @@ return [
 
     'driver' => 'rabbitmq',
     'queue' => env('RABBITMQ_QUEUE', 'default'),
-    'connection' => 'default',
+    'connection' => env('RABBITMQ_CONNECTION', 'default'),
 
     'hosts' => [
         [

--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -16,7 +16,7 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
     public function register(): void
     {
         $configPath = with(config_path('rabbitmq.php'), function (string $path) {
-            return file_exists($path) ? $path : __DIR__ . '/../config/rabbitmq.php';
+            return file_exists($path) ? $path : __DIR__.'/../config/rabbitmq.php';
         });
         $this->replaceConfigRecursivelyFrom($configPath, 'queue.connections.rabbitmq');
 
@@ -69,7 +69,7 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
         });
 
         $this->publishes([
-            __DIR__ . '/../config/rabbitmq.php' => config_path('rabbitmq.php'),
+            __DIR__.'/../config/rabbitmq.php' => config_path('rabbitmq.php'),
         ], 'config');
     }
 }

--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -72,6 +72,6 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../config/rabbitmq.php' => config_path('rabbitmq.php'),
-        ], 'config');
+        ], 'rabbitmq-config');
     }
 }

--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -18,7 +18,9 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
         $configPath = with(config_path('rabbitmq.php'), function (string $path) {
             return file_exists($path) ? $path : __DIR__.'/../config/rabbitmq.php';
         });
-        $this->replaceConfigRecursivelyFrom($configPath, 'queue.connections.rabbitmq');
+        method_exists($this, 'replaceConfigRecursivelyFrom')
+            ? $this->replaceConfigRecursivelyFrom($configPath, 'queue.connections.rabbitmq')
+            : $this->mergeConfigFrom($configPath, 'queue.connections.rabbitmq');
 
         if ($this->app->runningInConsole()) {
             $this->app->singleton('rabbitmq.consumer', function ($app) {

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -2,6 +2,7 @@
 
 namespace VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Connection;
 
+use Closure;
 use Illuminate\Support\Arr;
 use PhpAmqpLib\Connection\AMQPConnectionConfig;
 
@@ -32,8 +33,10 @@ class ConfigFactory
             );
 
             // Set the connection name if specified
-            if ($connectionName = value(Arr::get($config, 'connection_name'), $config)) {
-                $connectionConfig->setConnectionName($connectionName);
+            if ($name = Arr::get($config, 'connection_name')) {
+                $connectionConfig->setConnectionName(
+                    value(is_callable($name) ? Closure::fromCallable($name) : $name, $config)
+                );
             }
 
             if ($connectionConfig->isSecure()) {

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -35,7 +35,7 @@ class ConfigFactory
             // Set the connection name if specified
             if ($name = Arr::get($config, 'connection_name')) {
                 $connectionConfig->setConnectionName(
-                    value(is_callable($name) ? Closure::fromCallable($name) : $name, $config)
+                    value(is_callable($name) ? Closure::fromCallable($name) : $name, $config) ?: ''
                 );
             }
 

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -31,6 +31,11 @@ class ConfigFactory
                 true)
             );
 
+            // Set the connection name if specified
+            if ($connectionName = value(Arr::get($config, 'connection_name'), $config)) {
+                $connectionConfig->setConnectionName($connectionName);
+            }
+
             if ($connectionConfig->isSecure()) {
                 self::getSLLOptionsFromConfig($connectionConfig, $config);
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,11 @@ use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * Will result in a fatal error if removed - don't know why.
+     */
+    public static $latestResponse = null;
+
     protected function getPackageProviders($app): array
     {
         return [


### PR DESCRIPTION
- Allows for static and dynamic setting of connection name, using either a `string` or a `Closure` which will receive the config array
- Allows for publishing the `rabbitmq.php` config and properly resolve merging if so