### PR TITLE
Add support for Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,6 @@ jobs:
             laravel: '^13.0'
           - php: '8.2'
             laravel: '^13.0'
-          - php: '8.3'
-            laravel: '^13.0'
 
     name: 'PHP ${{ matrix.php }} - Laravel: ${{matrix.laravel}} - ${{ matrix.stability }}'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,20 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         stability: ['prefer-lowest', 'prefer-stable']
-        laravel: ['^10.0', '^11.0', '^12.0']
+        laravel: ['^10.0', '^11.0', '^12.0', '^13.0']
         exclude:
           - php: '8.1'
             laravel: '^11.0'
           - php: '8.1'
             laravel: '^12.0'
+          - php: '8.1'
+            laravel: '^13.0'
+          - php: '8.2'
+            laravel: '^13.0'
+          - php: '8.3'
+            laravel: '^13.0'
 
     name: 'PHP ${{ matrix.php }} - Laravel: ${{matrix.laravel}} - ${{ matrix.stability }}'
 

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^10.0|^11.0|^12.0",
+        "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
         "php-amqplib/php-amqplib": "^v3.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "mockery/mockery": "^1.0",
         "laravel/horizon": "^5.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "laravel/pint": "^1.2",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -199,12 +199,12 @@ class Consumer extends Worker
      * @param  WorkerOptions|null  $options
      * @return int
      */
-    public function stop($status = 0, $options = null)
+    public function stop($status = 0, $options = null, $reason = null)
     {
         // Tell the server you are going to stop consuming.
         // It will finish up the last message and not send you any more.
         $this->channel->basic_cancel($this->consumerTag, false, true);
 
-        return parent::stop($status, $options);
+        return parent::stop($status, $options, $reason);
     }
 }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -197,6 +197,7 @@ class Consumer extends Worker
      *
      * @param  int  $status
      * @param  WorkerOptions|null  $options
+     * @param  string|null  $reason
      * @return int
      */
     public function stop($status = 0, $options = null, $reason = null)

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -96,38 +96,6 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
     /**
      * {@inheritdoc}
-     */
-    public function pendingSize($queue = null): int
-    {
-        return $this->size($queue);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function delayedSize($queue = null): int
-    {
-        return 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function reservedSize($queue = null): int
-    {
-        return 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function creationTimeOfOldestPendingJob($queue = null): ?int
-    {
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
      *
      * @throws AMQPProtocolChannelException
      */

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -96,6 +96,38 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
     /**
      * {@inheritdoc}
+     */
+    public function pendingSize($queue = null): int
+    {
+        return $this->size($queue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delayedSize($queue = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reservedSize($queue = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function creationTimeOfOldestPendingJob($queue = null): ?int
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @throws AMQPProtocolChannelException
      */


### PR DESCRIPTION
This pull request adds support for Laravel 13 and PHP 8.5, updates related dependencies, and introduces new queue metrics methods to improve compatibility and observability. It also extends the `stop` method in the consumer to accept an optional reason parameter for stopping.

**Framework and Dependency Updates:**

* Added support for Laravel 13 and PHP 8.5 in the test matrix (`.github/workflows/tests.yml`) and updated `composer.json` to require compatible versions for `illuminate/queue`, `laravel/framework`, `phpunit/phpunit`, and `orchestra/testbench`. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL16-R27) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L14-R23)

**Queue Metrics Enhancements:**

* Implemented new methods in `RabbitMQQueue` to provide queue metrics: `pendingSize`, `delayedSize`, `reservedSize`, and `creationTimeOfOldestPendingJob`, improving compatibility with Laravel's queue monitoring features.

**Consumer Behavior Improvements:**

* Modified the `stop` method in `Consumer` to accept an optional `$reason` parameter and pass it to the parent, allowing for more descriptive shutdowns.