### PR TITLE
feat: add Laravel 13 and PHP 8.5 support

### DIFF
--- a/CHANGELOG-14x.md
+++ b/CHANGELOG-14x.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased](https://github.com/vyuldashev/laravel-queue-rabbitmq/compare/v13.3.0...master)
+- Add Laravel 13 compatibility to the queue constraints.
+- Allow PHP 8.5-compatible `php-amqplib/php-amqplib` and PHPUnit 12 in the development matrix.
+- Make Horizon an optional suggestion for fork validation because the stable Horizon line has not declared Laravel 13 support yet.
 
 ## [14.0.0]
 - First release compatible with Laravel 11

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,15 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^10.0|^11.0|^12.0",
-        "php-amqplib/php-amqplib": "^v3.6"
+        "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+        "php-amqplib/php-amqplib": "^3.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "mockery/mockery": "^1.0",
-        "laravel/horizon": "^5.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "laravel/pint": "^1.2",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {
@@ -43,7 +42,8 @@
         }
     },
     "suggest": {
-        "ext-pcntl": "Required to use all features of the queue consumer."
+        "ext-pcntl": "Required to use all features of the queue consumer.",
+        "laravel/horizon": "Required only when using the Horizon worker integration."
     },
     "scripts": {
         "test": [
@@ -54,6 +54,5 @@
         "test:unit": "@php vendor/bin/phpunit",
         "fix:style": "@php vendor/bin/pint -v"
     },
-    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -197,14 +197,15 @@ class Consumer extends Worker
      *
      * @param  int  $status
      * @param  WorkerOptions|null  $options
+     * @param  mixed  $reason
      * @return int
      */
-    public function stop($status = 0, $options = null)
+    public function stop($status = 0, $options = null, $reason = null)
     {
         // Tell the server you are going to stop consuming.
         // It will finish up the last message and not send you any more.
         $this->channel->basic_cancel($this->consumerTag, false, true);
 
-        return parent::stop($status, $options);
+        return parent::stop($status, $options, $reason);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds Laravel 13 and PHP 8.5 compatibility to `vladimir-yuldashev/laravel-queue-rabbitmq`.

## Changes

- widen `illuminate/queue` support through Laravel 13
- widen package test matrix for Laravel 13 / Testbench 11 / PHPUnit 12
- bump `php-amqplib/php-amqplib` to `^3.7`
- make Horizon an optional suggestion instead of a required dev dependency
- update `Consumer::stop()` to match Laravel 13's `Worker::stop($status, $options, $reason)` signature

## Validation

- `composer validate` passes in the package fork
- validated in a real Laravel 13.1.1 / PHP 8.5 application upgrade

## Notes

This keeps the package compatible with newer Laravel worker behavior without changing the core queue-driver design.
