### PR TITLE
Document the exceptions thrown by publishBatch()

### DIFF
--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -42,7 +42,7 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
             });
 
             $this->commands([
-                Console\ConsumeCommand::class,
+                ConsumeCommand::class,
             ]);
         }
 

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -190,6 +190,9 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     }
 
     /**
+     * @throws AMQPChannelClosedException
+     * @throws AMQPConnectionClosedException
+     * @throws AMQPConnectionBlockedException
      * @throws AMQPProtocolChannelException
      */
     protected function publishBatch($jobs, $data = '', $queue = null): void
@@ -750,6 +753,11 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         $this->getChannel()->basic_publish($msg, $exchange, $destination, $mandatory, $immediate, $ticket);
     }
 
+    /**
+     * @throws AMQPChannelClosedException
+     * @throws AMQPConnectionClosedException
+     * @throws AMQPConnectionBlockedException
+     */
     protected function batchPublish(): void
     {
         $this->getChannel()->publish_batch();

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -9,8 +9,9 @@ use PhpAmqpLib\Connection\AMQPSSLConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestSSLConnection;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase;
 
-class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase
+class ConnectorTest extends TestCase
 {
     public function testLazyConnection(): void
     {


### PR DESCRIPTION
Hi,

I work on a project where we override `publishBatch()` like this:
```php
try {
    parent::publishBatch($jobs, $data, $queue);
} catch (AMQPConnectionClosedException|AMQPChannelClosedException|AMQPProtocolChannelException) {
    $this->reconnect();
    parent::publishBatch($jobs, $data, $queue);
}
```

but PHPStan emits this error:
```
Dead catch - PhpAmqpLib\Exception\AMQPChannelClosedException is never thrown in the try block.                                               
🪪  catch.neverThrown                                                  
Dead catch - PhpAmqpLib\Exception\AMQPConnectionClosedException is never thrown in the try block.                                         
🪪  catch.neverThrown                                                  
```

These changes will fix this issue.