### PR TITLE
Fix Consumer currentJob visibility for Laravel 13.7

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -32,8 +32,14 @@ class Consumer extends Worker
     /** @var AMQPChannel */
     protected $channel;
 
-    /** @var object|null */
-    protected $currentJob;
+    /**
+     * The job currently being processed.
+     *
+     * Must remain public to match Illuminate\Queue\Worker::$currentJob.
+     *
+     * @var object|null
+     */
+    public $currentJob;
 
     public function setContainer(Container $value): void
     {

--- a/src/LaravelQueueRabbitMQServiceProvider.php
+++ b/src/LaravelQueueRabbitMQServiceProvider.php
@@ -42,7 +42,7 @@ class LaravelQueueRabbitMQServiceProvider extends ServiceProvider
             });
 
             $this->commands([
-                Console\ConsumeCommand::class,
+                ConsumeCommand::class,
             ]);
         }
 

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -9,8 +9,9 @@ use PhpAmqpLib\Connection\AMQPSSLConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue;
 use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\Mocks\TestSSLConnection;
+use VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase;
 
-class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCase
+class ConnectorTest extends TestCase
 {
     public function testLazyConnection(): void
     {


### PR DESCRIPTION
Closes https://github.com/vyuldashev/laravel-queue-rabbitmq/issues/659

## Summary

Laravel 13.7 [introduced](https://github.com/laravel/framework/commit/86cb6af75924838e97e2b426326324cd6b543c6c#diff-d1e6684c51f2038f97ba12fee146a8f77b1bca1c747b29951ff5746446165a91R87) `Illuminate\Queue\Worker::$currentJob` as a public property as part of the interruptible jobs / worker signal handling changes.

This package already declares `Consumer::$currentJob`, but it was `protected`. Once `Consumer` extends the updated framework `Worker`, PHP treats that as an incompatible property redeclaration because child visibility cannot be narrower than the parent.

This change aligns the visibility with upstream by making `Consumer::$currentJob` public.

## Why this approach

I intentionally kept the same property name instead of renaming it:

- Laravel now uses `Worker::$currentJob` as part of its signal-aware worker behavior.
- Renaming the package property would risk the package and the framework tracking different "current job" state.
- Matching the upstream property name and visibility is the smallest and safest compatibility fix.

I also added a short docblock note in `Consumer` to explain why the property must remain public.