### PR TITLE
Fix: scope $currentJob to daemon() (resolves #663 and #661)

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -32,8 +32,6 @@ class Consumer extends Worker
     /** @var AMQPChannel */
     protected $channel;
 
-    protected $currentJob;
-
     public function setContainer(Container $value): void
     {
         $this->container = $value;
@@ -95,6 +93,14 @@ class Consumer extends Worker
             $arguments['priority'] = ['I', $this->maxPriority];
         }
 
+        // Tracked locally instead of on $this to avoid two problems:
+        //   1. Illuminate\Queue\Worker::$currentJob became public in Laravel 13.7,
+        //      so redeclaring it on Consumer hits a visibility narrowing error.
+        //   2. Worker::runJob() may reset $this->currentJob to null after each job,
+        //      which made the "if (currentJob === null) sleep" branch trigger after
+        //      every successful job and starved throughput (see #661).
+        $currentJob = null;
+
         $this->channel->basic_consume(
             $queue,
             $this->consumerTag,
@@ -102,7 +108,7 @@ class Consumer extends Worker
             false,
             false,
             false,
-            function (AMQPMessage $message) use ($connection, $options, $connectionName, $queue, $jobClass, &$jobsProcessed): void {
+            function (AMQPMessage $message) use ($connection, $options, $connectionName, $queue, $jobClass, &$jobsProcessed, &$currentJob): void {
                 $job = new $jobClass(
                     $this->container,
                     $connection,
@@ -111,7 +117,7 @@ class Consumer extends Worker
                     $queue
                 );
 
-                $this->currentJob = $job;
+                $currentJob = $job;
 
                 if ($this->supportsAsyncSignals()) {
                     $this->registerTimeoutHandler($job, $options);
@@ -156,8 +162,8 @@ class Consumer extends Worker
                 $this->stopWorkerIfLostConnection($exception);
             }
 
-            // If no job is got off the queue, we will need to sleep the worker.
-            if ($this->currentJob === null) {
+            // If no job was consumed during this wait() cycle, sleep the worker.
+            if ($currentJob === null) {
                 $this->sleep($options->sleep);
             }
 
@@ -169,14 +175,14 @@ class Consumer extends Worker
                 $lastRestart,
                 $startTime,
                 $jobsProcessed,
-                $this->currentJob
+                $currentJob
             );
 
             if (! is_null($status)) {
                 return $this->stop($status, $options);
             }
 
-            $this->currentJob = null;
+            $currentJob = null;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #663 and closes #661 by removing `Consumer::$currentJob` as a class property and tracking it as a local variable inside `daemon()` instead.

## Background

- **#663** — On Laravel 13.7, `Illuminate\Queue\Worker::$currentJob` became `public`. Redeclaring it as `protected` on `Consumer` triggers a PHP visibility-narrowing fatal error during `package:discover`. Confirmed against `v14.5.3` and current `master` (`63e5c37`).
- **#661** — PR #660 made `Consumer::$currentJob` public to fix #663, but introduced a regression: `Worker::runJob()` in Laravel 13 resets `$this->currentJob = null` after every successful job, so the outer `if ($this->currentJob === null) { sleep(); }` branch in `daemon()` started firing after every job. The consumer slept for `--sleep=3` seconds between every job, killing throughput, and `--stop-when-empty` also broke.
- PR #660 was reverted in `63e5c37` ("wip"), which restored throughput but brought back the original visibility error in #663. The package is currently broken either way on Laravel 13.7.

## Fix

`$currentJob` is only read or written inside `Consumer::daemon()` — no getter, no other method uses it. So make it a local variable captured by reference into the `basic_consume` callback:

```php
$currentJob = null;

$this->channel->basic_consume(
    /* ... */,
    function (AMQPMessage $message) use (/* ... */, &$currentJob): void {
        // ...
        $currentJob = $job;
        // ...
    },
    /* ... */
);

while ($this->channel->is_consuming()) {
    // ...
    if ($currentJob === null) {
        $this->sleep($options->sleep);
    }
    $status = $this->stopIfNecessary(/* ... */, $currentJob);
    if (! is_null($status)) {
        return $this->stop($status, $options);
    }
    $currentJob = null;
}
```

This:

1. **Resolves #663** — there is no more redeclaration of `$currentJob` on `Consumer`, so the visibility-narrowing error cannot occur.
2. **Resolves #661** — the local variable is no longer at the mercy of whatever `Worker::runJob()` does to its own `$this->currentJob`. The "sleep when nothing was consumed" branch only fires when the `wait()` cycle truly produced no message.
3. Preserves existing semantics: the same job reference still flows into `stopIfNecessary()`, and the per-iteration reset still happens at the end of the loop.

## Manual test

Reproduced both bugs and verified the fix against:

- PHP 8.3
- `laravel/framework` v13.7.0
- This branch

`composer install` and `php artisan package:discover --ansi` complete without errors. `php artisan queue:work rabbitmq` consumes back-to-back jobs without the 3s gap between them. `--stop-when-empty` exits as soon as the queue is drained.

## Test plan

- [ ] Existing test suite passes on CI.
- [ ] Reviewer reproduces against Laravel 13.7 and confirms throughput is back.
- [ ] Reviewer confirms behavior on Laravel 11/12 is unchanged.